### PR TITLE
Fix startVote logic in voteManager

### DIFF
--- a/core/vote/vote_manager.go
+++ b/core/vote/vote_manager.go
@@ -95,8 +95,8 @@ func (voteManager *VoteManager) loop() {
 				log.Debug("downloader is in startEvent mode, will not startVote")
 				startVote = false
 			case downloader.FailedEvent:
-				log.Debug("downloader is in FailedEvent mode, will not startVote")
-				startVote = false
+				log.Debug("downloader is in FailedEvent mode, set startVote flag as true to match miner logic")
+				startVote = true
 			case downloader.DoneEvent:
 				log.Debug("downloader is in DoneEvent mode, set the startVote flag to true")
 				startVote = true

--- a/core/vote/vote_manager.go
+++ b/core/vote/vote_manager.go
@@ -95,7 +95,7 @@ func (voteManager *VoteManager) loop() {
 				log.Debug("downloader is in startEvent mode, will not startVote")
 				startVote = false
 			case downloader.FailedEvent:
-				log.Debug("downloader is in FailedEvent mode, set startVote flag as true to match miner logic")
+				log.Debug("downloader is in FailedEvent mode, set startVote flag as true")
 				startVote = true
 			case downloader.DoneEvent:
 				log.Debug("downloader is in DoneEvent mode, set the startVote flag to true")


### PR DESCRIPTION
In previous logic, while failedEvent sent by downloader, miner will still start, so it's required for voteManager to match this logic, set startVote as true if failedEvent received.