### PR TITLE
change boneh fork liveness

### DIFF
--- a/common/math/integer.go
+++ b/common/math/integer.go
@@ -96,3 +96,7 @@ func SafeMul(x, y uint64) (uint64, bool) {
 	hi, lo := bits.Mul64(x, y)
 	return lo, hi != 0
 }
+
+func CeilDiv(x, y int) int {
+	return (x + y - 1) / y
+}

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -391,10 +391,7 @@ func getVoteAttestationFromHeader(header *types.Header, chainConfig *params.Chai
 func getSignRecentlyLimit(blockNumber *big.Int, validatorsNumber int, chainConfig *params.ChainConfig) int {
 	limit := validatorsNumber/2 + 1
 	if chainConfig.IsBoneh(blockNumber) {
-		limit = validatorsNumber * 2 / 3
-		if limit == 0 {
-			limit = 1 // limit should no little than 1.
-		}
+		limit = int(math.Ceil(float64(validatorsNumber) * 2 / 3))
 	}
 	return limit
 }
@@ -478,7 +475,7 @@ func (p *Parlia) verifyVoteAttestation(chain consensus.ChainHeaderReader, header
 	}
 
 	// The valid voted validators should be no less than 2/3 validators.
-	if len(votedAddrs) < len(snap.Validators)*2/3 || len(votedAddrs) == 0 {
+	if len(votedAddrs) < int(math.Ceil(float64(len(snap.Validators))*2/3)) {
 		return fmt.Errorf("invalid attestation, not enough validators voted")
 	}
 
@@ -820,7 +817,7 @@ func (p *Parlia) assembleVoteAttestation(chain consensus.ChainHeaderReader, head
 		return err
 	}
 	votes := p.VotePool.FetchVoteByBlockHash(parent.Hash())
-	if len(votes) < len(snap.Validators)*2/3 || len(votes) == 0 { // len(snap.Validators)*2/3 may equal to 0
+	if len(votes) < int(math.Ceil(float64(len(snap.Validators))*2/3)) {
 		return nil
 	}
 

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -391,7 +391,10 @@ func getVoteAttestationFromHeader(header *types.Header, chainConfig *params.Chai
 func getSignRecentlyLimit(blockNumber *big.Int, validatorsNumber int, chainConfig *params.ChainConfig) int {
 	limit := validatorsNumber/2 + 1
 	if chainConfig.IsBoneh(blockNumber) {
-		limit = validatorsNumber*2/3 + 1
+		limit = validatorsNumber * 2 / 3
+		if limit == 0 {
+			limit = 1 // limit should no little than 1.
+		}
 	}
 	return limit
 }
@@ -475,7 +478,7 @@ func (p *Parlia) verifyVoteAttestation(chain consensus.ChainHeaderReader, header
 	}
 
 	// The valid voted validators should be no less than 2/3 validators.
-	if len(votedAddrs) <= len(snap.Validators)*2/3 {
+	if len(votedAddrs) < len(snap.Validators)*2/3 || len(votedAddrs) == 0 {
 		return fmt.Errorf("invalid attestation, not enough validators voted")
 	}
 
@@ -817,7 +820,7 @@ func (p *Parlia) assembleVoteAttestation(chain consensus.ChainHeaderReader, head
 		return err
 	}
 	votes := p.VotePool.FetchVoteByBlockHash(parent.Hash())
-	if len(votes) <= len(snap.Validators)*2/3 {
+	if len(votes) < len(snap.Validators)*2/3 || len(votes) == 0 { // len(snap.Validators)*2/3 may equal to 0
 		return nil
 	}
 

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/gopool"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	cmath "github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/consensus/misc"
 	"github.com/ethereum/go-ethereum/core"
@@ -391,7 +392,7 @@ func getVoteAttestationFromHeader(header *types.Header, chainConfig *params.Chai
 func getSignRecentlyLimit(blockNumber *big.Int, validatorsNumber int, chainConfig *params.ChainConfig) int {
 	limit := validatorsNumber/2 + 1
 	if chainConfig.IsBoneh(blockNumber) {
-		limit = int(math.Ceil(float64(validatorsNumber) * 2 / 3))
+		limit = cmath.CeilDiv(validatorsNumber*2, 3)
 	}
 	return limit
 }
@@ -475,7 +476,7 @@ func (p *Parlia) verifyVoteAttestation(chain consensus.ChainHeaderReader, header
 	}
 
 	// The valid voted validators should be no less than 2/3 validators.
-	if len(votedAddrs) < int(math.Ceil(float64(len(snap.Validators))*2/3)) {
+	if len(votedAddrs) < cmath.CeilDiv(len(snap.Validators)*2, 3) {
 		return fmt.Errorf("invalid attestation, not enough validators voted")
 	}
 
@@ -817,7 +818,7 @@ func (p *Parlia) assembleVoteAttestation(chain consensus.ChainHeaderReader, head
 		return err
 	}
 	votes := p.VotePool.FetchVoteByBlockHash(parent.Hash())
-	if len(votes) < int(math.Ceil(float64(len(snap.Validators))*2/3)) {
+	if len(votes) < cmath.CeilDiv(len(snap.Validators)*2, 3) {
 		return nil
 	}
 

--- a/go.sum
+++ b/go.sum
@@ -526,8 +526,6 @@ github.com/herumi/bls-eth-go-binary v0.0.0-20210917013441-d37c07cfda4e h1:wCMygK
 github.com/herumi/bls-eth-go-binary v0.0.0-20210917013441-d37c07cfda4e/go.mod h1:luAnRm3OsMQeokhGzpYmc0ZKwawY7o87PUEP11Z7r7U=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=
 github.com/holiman/bloomfilter/v2 v2.0.3/go.mod h1:zpoh+gs7qcpqrHr3dB55AMiJwo0iURXE7ZOP9L9hSkA=
-github.com/holiman/uint256 v1.1.1 h1:4JywC80b+/hSfljFlEBLHrrh+CIONLDz9NuFl0af4Mw=
-github.com/holiman/uint256 v1.1.1/go.mod h1:y4ga/t+u+Xwd7CpDgZESaRcWy0I7XMlTMA25ApIH5Jw=
 github.com/holiman/uint256 v1.2.0 h1:gpSYcPLWGv4sG43I2mVLiDZCNDh/EpGjSk8tmtxitHM=
 github.com/holiman/uint256 v1.2.0/go.mod h1:y4ga/t+u+Xwd7CpDgZESaRcWy0I7XMlTMA25ApIH5Jw=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=


### PR DESCRIPTION
### Description

There should be enough online validators to vote for the fast finality, we think one block should gather 2/3*v+1 votes to get justified before, so the online validators should be at least 2/3*v+1.

However, once a block gathered 2/3*v votes, we can regard this block as justified, so we change the liveness from 2/3*v+1 to 2/3*v.

### Rationale

We assume there are less than 1/3*v validators who are malicious in the network, once a block gathered 2/3*v+ votes, we can regard this block as justified, and we can prove there will be no two blocks at the same height get justified under this assumption and constraints.

Assume the validators number is v, malicious validators are less than 1/3*v, the number is 1/3*v-1, if two blocks in the same height have received 2/3*v votes, then the total votes should be 4/3*v, each malicious validators can vote two votes, they can have 2/3*v-2 votes, so the honest validator should give 4/*3*v - (2/3*v - 2) = 2/3*v+2 votes, that means at least one honest validator has obeyed the vote rules.

From the upper proof, we can see the liveness should be set to 2/3*v other than 2/3*v+1.

### Example
NA

### Changes

Notable changes: 
* change liveness from 2/3*v+1 to 2/3*v
* should carefully deal with the sign recently limit equal to 0, that won't make the blockchain work
