### PR TITLE
Fix: a bug of Parallel 2.0 reused object pool

### DIFF
--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -1144,7 +1144,7 @@ func (s *StateDB) PutSyncPool() {
 	for key := range s.parallel.codeReadsInSlot {
 		delete(s.parallel.codeReadsInSlot, key)
 	}
-	addressToStructPool.Put(s.parallel.codeReadsInSlot)
+	addressToBytesPool.Put(s.parallel.codeReadsInSlot)
 
 	for key := range s.parallel.codeHashReadsInSlot {
 		delete(s.parallel.codeHashReadsInSlot, key)


### PR DESCRIPTION
### Description
It is a typo, a small bug fix on `PutSyncPool()`

### Rationale
none
### Example
none
### Changes
For detail pls refer the commit code.

