### PR TITLE
Nathan/fast finality bugfix

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -59,7 +59,7 @@ const (
 	validatorBytesLength           = common.AddressLength
 	validatorBytesLengthAfterBoneh = common.AddressLength + types.BLSPublicKeyLength
 	validatorNumberSizeAfterBoneh  = 1  // Fixed number of extra prefix bytes reserved for validator number
-	naturallyJustifiedDist         = 15 // The distance to naturally justify a block
+	naturallyJustifiedDist         = 14 // The distance to naturally justify a block
 
 	wiggleTime         = uint64(1) // second, Random delay (per signer) to allow concurrent signers
 	initialBackOffTime = uint64(1) // second

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -624,8 +624,8 @@ func (bc *BlockChain) reorgNeededWithFastFinality(current *types.Header, header 
 		return bc.forker.ReorgNeeded(current, header)
 	} else if finalized.Number.Uint64() > ancestor.Number.Uint64() && curFinalized.Number.Uint64() > ancestor.Number.Uint64() {
 		log.Crit("find two conflict finalized headers", "header1", finalized, "header2", curFinalized)
-		return false, nil
-	} else if finalized.Number.Uint64() == curFinalized.Number.Uint64() {
+	}
+	if finalized.Number.Uint64() == curFinalized.Number.Uint64() {
 		return bc.forker.ReorgNeeded(current, header)
 	} else if finalized.Number.Uint64() > curFinalized.Number.Uint64() {
 		return true, nil

--- a/core/headerchain.go
+++ b/core/headerchain.go
@@ -156,8 +156,8 @@ func (hc *HeaderChain) reorgNeededWithFastFinality(forker *ForkChoice, current *
 		return forker.ReorgNeeded(current, header)
 	} else if finalized.Number.Uint64() > ancestor.Number.Uint64() && curFinalized.Number.Uint64() > ancestor.Number.Uint64() {
 		log.Crit("find two conflict finalized headers", "header1", finalized, "header2", curFinalized)
-		return false, nil
-	} else if finalized.Number.Uint64() == curFinalized.Number.Uint64() {
+	}
+	if finalized.Number.Uint64() == curFinalized.Number.Uint64() {
 		return forker.ReorgNeeded(current, header)
 	} else if finalized.Number.Uint64() > curFinalized.Number.Uint64() {
 		return true, nil

--- a/core/vote/vote_manager.go
+++ b/core/vote/vote_manager.go
@@ -14,7 +14,7 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 )
 
-const naturallyJustifiedDist = 15 // The distance to naturally justify a block
+const naturallyJustifiedDist = 14 // The distance to naturally justify a block
 
 // VoteManager will handle the vote produced by self.
 type VoteManager struct {


### PR DESCRIPTION
Description
1. change naturallyJustifiedDist to 14 from 15, for keeping consistency with vote quorum
2. make explicit rules for reorganization even when conflicting blocks are finalized,
	ensure that the chain will not fork in this extreme scenario

Rationale
The pervious logic is wrong, we should fix them.

Example
NA

Changes
Notable changes:

NA