### PR TITLE
feat: update bls verification precompile contract

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -275,6 +275,7 @@ type sha256hash struct{}
 func (c *sha256hash) RequiredGas(input []byte) uint64 {
 	return uint64(len(input)+31)/32*params.Sha256PerWordGas + params.Sha256BaseGas
 }
+
 func (c *sha256hash) Run(input []byte) ([]byte, error) {
 	h := sha256.Sum256(input)
 	return h[:], nil
@@ -290,6 +291,7 @@ type ripemd160hash struct{}
 func (c *ripemd160hash) RequiredGas(input []byte) uint64 {
 	return uint64(len(input)+31)/32*params.Ripemd160PerWordGas + params.Ripemd160BaseGas
 }
+
 func (c *ripemd160hash) Run(input []byte) ([]byte, error) {
 	ripemd := ripemd160.New()
 	ripemd.Write(input)
@@ -306,6 +308,7 @@ type dataCopy struct{}
 func (c *dataCopy) RequiredGas(input []byte) uint64 {
 	return uint64(len(input)+31)/32*params.IdentityPerWordGas + params.IdentityBaseGas
 }
+
 func (c *dataCopy) Run(in []byte) ([]byte, error) {
 	return in, nil
 }
@@ -336,9 +339,10 @@ var (
 // modexpMultComplexity implements bigModexp multComplexity formula, as defined in EIP-198
 //
 // def mult_complexity(x):
-//    if x <= 64: return x ** 2
-//    elif x <= 1024: return x ** 2 // 4 + 96 * x - 3072
-//    else: return x ** 2 // 16 + 480 * x - 199680
+//
+//	if x <= 64: return x ** 2
+//	elif x <= 1024: return x ** 2 // 4 + 96 * x - 3072
+//	else: return x ** 2 // 16 + 480 * x - 199680
 //
 // where is x is max(length_of_MODULUS, length_of_BASE)
 func modexpMultComplexity(x *big.Int) *big.Int {
@@ -1122,32 +1126,37 @@ func (c *blsSignatureVerify) RequiredGas(input []byte) uint64 {
 	return params.BlsSignatureVerifyGas
 }
 
+const (
+	msgHashLength         = uint64(32)
+	signatureLength       = uint64(96)
+	singleBlsPubkeyLength = uint64(48)
+)
+
 // Run input:
 // msg      | signature | [{bls pubkey}] |
 // 32 bytes | 96 bytes  | [{48 bytes}]   |
 func (c *blsSignatureVerify) Run(input []byte) ([]byte, error) {
-	minimumLength := uint64(32) + uint64(96)
-	singlePubkeyLength := uint64(48)
-
+	minimumLength := msgHashLength + signatureLength
 	inputLen := uint64(len(input))
-	if inputLen <= minimumLength || (inputLen-minimumLength)%singlePubkeyLength != 0 {
-		return nil, fmt.Errorf("expected input size %d+%d*N, actual input size: %d", minimumLength, singlePubkeyLength, inputLen)
+	if inputLen <= minimumLength ||
+		(inputLen-minimumLength)%singleBlsPubkeyLength != 0 {
+		return nil, fmt.Errorf("expected input size %d+%d*N, actual input size: %d", minimumLength, singleBlsPubkeyLength, inputLen)
 	}
 
 	var msg [32]byte
-	msgBytes := getData(input, 0, 32)
+	msgBytes := getData(input, 0, msgHashLength)
 	copy(msg[:], msgBytes)
 
-	signatureBytes := getData(input, 32, 96)
+	signatureBytes := getData(input, msgHashLength, signatureLength)
 	sig, err := bls.SignatureFromBytes(signatureBytes)
 	if err != nil {
 		return nil, fmt.Errorf("invalid signature: %v", err)
 	}
 
-	pubKeyNumber := (inputLen - minimumLength) / singlePubkeyLength
+	pubKeyNumber := (inputLen - minimumLength) / singleBlsPubkeyLength
 	pubKeys := make([]bls.PublicKey, pubKeyNumber)
 	for i := uint64(0); i < pubKeyNumber; i++ {
-		pubKeyBytes := getData(input, 128+i*singlePubkeyLength, 48)
+		pubKeyBytes := getData(input, minimumLength+i*singleBlsPubkeyLength, singleBlsPubkeyLength)
 		pubKey, err := bls.PublicKeyFromBytes(pubKeyBytes)
 		if err != nil {
 			return nil, err

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -65,7 +65,7 @@ var allPrecompiles = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{16}):   &bls12381Pairing{},
 	common.BytesToAddress([]byte{17}):   &bls12381MapG1{},
 	common.BytesToAddress([]byte{18}):   &bls12381MapG2{},
-	common.BytesToAddress([]byte{102}):  &voteSignatureVerify{},
+	common.BytesToAddress([]byte{102}):  &blsSignatureVerify{},
 }
 
 // EIP-152 test vectors
@@ -180,7 +180,7 @@ func benchmarkPrecompiled(addr string, test precompiledTest, bench *testing.B) {
 		// Keep it as uint64, multiply 100 to get two digit float later
 		mgasps := (100 * 1000 * gasUsed) / elapsed
 		bench.ReportMetric(float64(mgasps)/100, "mgas/s")
-		//Check if it is correct
+		// Check if it is correct
 		if err != nil {
 			bench.Error(err)
 			return
@@ -232,10 +232,10 @@ func BenchmarkPrecompiledIdentity(bench *testing.B) {
 	benchmarkPrecompiled("04", t, bench)
 }
 
-// Benchmarks the sample inputs from the voteSignatureVerify precompile.
-func BenchmarkPrecompiledVoteSignatureVerify(bench *testing.B) {
+// Benchmarks the sample inputs from the blsSignatureVerify precompile.
+func BenchmarkPrecompiledBlsSignatureVerify(bench *testing.B) {
 	t := precompiledTest{
-		Input:    "000000000000000000000000000000000000000000000000000000000000000a000000000000000000000000000000000000000000000000000000000000000c555d45d77921e0f26487706179f73c5f8539744b55147c73a3621366bf809c066c8781959ce3621f67c9345da9b5e01ce5113d7b5ae3c6dcd3ca88ad4ed9023fa55c8188060c74f1791eefc78e8aacf0c044e3f6317fe5eadce8ba9db2d19da83e41364c3d6802175acaa392d576a95206d83e5bbfc6022b53c288dc5b60cfe1722298007f1a4b97f47383a9fe1cb7bb5250783e89f3720b7a37bec026ece0b6b32d4d46a7127dcc865f0d30f2ee3dcd5983b686f4e3a9202afc8b608652001c9938906ae1ff1417486096e32511f1bc",
+		Input:    "f2d8e8e5bf354429e3ce8b97c4e88f7a0bf7bc917e856de762ed6d70dd8ec2d289a04d63285e4b45309e7c180ea82565e375dd62c7b80d957aea4c9b7e16bdb28a0f910036bd3220fe3d7614fb137a8f0a68b3c564ddd214b5041d8f7a124e6e7285ac42635e75eeb9051a052fb500b1c2bc23bd4290db59fc02be11f2b80896b6e22d5b8dd31ba2e49b13cd6be19fcd01c1e23af3e5165d88d8b9deaf38baa77770fa6a358e2eebdffd1bd8a1eb7386",
 		Expected: "01",
 		Name:     "",
 	}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -54,9 +54,9 @@ func (evm *EVM) precompile(addr common.Address) (PrecompiledContract, bool) {
 	case evm.chainRules.IsBoneh:
 		precompiles = PrecompiledContractsBoneh
 	case evm.chainRules.IsMoran:
-		precompiles = PrecompiledContractsIsMoran
+		precompiles = PrecompiledContractsMoran
 	case evm.chainRules.IsNano:
-		precompiles = PrecompiledContractsIsNano
+		precompiles = PrecompiledContractsNano
 	case evm.chainRules.IsBerlin:
 		precompiles = PrecompiledContractsBerlin
 	case evm.chainRules.IsIstanbul:
@@ -255,7 +255,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 			gas = 0
 		}
 		// TODO: consider clearing up unused snapshots:
-		//} else {
+		// } else {
 		//	evm.StateDB.DiscardSnapshot(snapshot)
 	}
 	return ret, gas, err

--- a/params/protocol_params.go
+++ b/params/protocol_params.go
@@ -132,14 +132,14 @@ const (
 	TendermintHeaderValidateGas uint64 = 3000 // Gas for validate tendermiint consensus state
 	IAVLMerkleProofValidateGas  uint64 = 3000 // Gas for validate merkle proof
 
-	EcrecoverGas           uint64 = 3000  // Elliptic curve sender recovery gas price
-	Sha256BaseGas          uint64 = 60    // Base price for a SHA256 operation
-	Sha256PerWordGas       uint64 = 12    // Per-word price for a SHA256 operation
-	Ripemd160BaseGas       uint64 = 600   // Base price for a RIPEMD160 operation
-	Ripemd160PerWordGas    uint64 = 120   // Per-word price for a RIPEMD160 operation
-	IdentityBaseGas        uint64 = 15    // Base price for a data copy operation
-	IdentityPerWordGas     uint64 = 3     // Per-work price for a data copy operation
-	VoteSignatureVerifyGas uint64 = 35000 // Finality signature verify gas price
+	EcrecoverGas          uint64 = 3000 // Elliptic curve sender recovery gas price
+	Sha256BaseGas         uint64 = 60   // Base price for a SHA256 operation
+	Sha256PerWordGas      uint64 = 12   // Per-word price for a SHA256 operation
+	Ripemd160BaseGas      uint64 = 600  // Base price for a RIPEMD160 operation
+	Ripemd160PerWordGas   uint64 = 120  // Per-word price for a RIPEMD160 operation
+	IdentityBaseGas       uint64 = 15   // Base price for a data copy operation
+	IdentityPerWordGas    uint64 = 3    // Per-work price for a data copy operation
+	BlsSignatureVerifyGas uint64 = 3500 // BLS signature verify gas price
 
 	Bn256AddGasByzantium             uint64 = 500    // Byzantium gas needed for an elliptic curve addition
 	Bn256AddGasIstanbul              uint64 = 150    // Gas needed for an elliptic curve addition


### PR DESCRIPTION
### Description

This pr it to update the bls signature verification precompile contract.

### Rationale

The old precompile contract is only for fast finality's vote signature verification. In order to make it more general, we update the function.

### Example

![image](https://user-images.githubusercontent.com/48975233/212800635-cda6ddaf-58ee-4054-ab16-6301d0f729ac.png)

### Changes

Notable changes: 
* update bls verification precompile contract
