### PR TITLE
improved boundary handling and related annotations in core/vote

### DIFF
--- a/core/vote/vote_manager.go
+++ b/core/vote/vote_manager.go
@@ -178,7 +178,7 @@ func (voteManager *VoteManager) UnderRules(header *types.Header) (bool, uint64, 
 
 	voteDataBuffer := voteManager.journal.voteDataBuffer
 	//Rule 1:  A validator must not publish two distinct votes for the same height.
-	if voteDataBuffer.Contains(header.Number.Uint64()) {
+	if voteDataBuffer.Contains(targetNumber) {
 		log.Debug("err: A validator must not publish two distinct votes for the same height.")
 		return false, 0, common.Hash{}
 	}
@@ -197,7 +197,7 @@ func (voteManager *VoteManager) UnderRules(header *types.Header) (bool, uint64, 
 			}
 		}
 	}
-	for blockNumber := targetNumber; blockNumber <= targetNumber+naturallyJustifiedDist; blockNumber++ {
+	for blockNumber := targetNumber + 1; blockNumber <= targetNumber+naturallyJustifiedDist; blockNumber++ {
 		if voteDataBuffer.Contains(blockNumber) {
 			voteData, ok := voteDataBuffer.Get(blockNumber)
 			if !ok {


### PR DESCRIPTION
### Description

### Rationale
1. we know that, 
   if x and b are integer
    _x -1 < b_       equal to         _x<=b_,  the latter one is more directly
    _x+1>a_         equal to         _x>=a_,  the latter one is more directly
    and the formers may lead to error easily, for example:

       // Make sure in the range currentHeight-256~currentHeight+11.

        if targetNumber+lowerLimitOfVoteBlockNumber-1 < headNumber || targetNumber > headNumber+upperLimitOfVoteBlockNumber {
                log.Debug("BlockNumber of vote is outside the range of header-256~header+11, will be discarded")
                return false
        }

        codes is not matched with annotations and log,
        and the code express 'currentHeight-255~currentHeight+11  indeed

 2. currentBlockNum+upperLimitOfVoteBlockNumber in included according to codes,
     **for simplicity**, both boundary will be set to be included, votes in the range [currentBlockNum-lowerLimitOfVoteBlockNumber, currentBlockNum+upperLimitOfVoteBlockNumber] will be stored,  so when prune
    `
       curVotesPq.Peek().TargetNumber+lowerLimitOfVoteBlockNumber-1 < latestBlockNumber
       -->
       curVotesPq.Peek().TargetNumber+lowerLimitOfVoteBlockNumber< latestBlockNumber
    `

 3.  we will add one vote to curVotes after basicVerify,
      so len(voteBox.voteMessages) should be less than maxVoteAmountPerBlock in basicVerify

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
