### PR TITLE
fix a bug about fetching snapshot of consensus when verifyVoteAttesta…

### DIFF
--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -446,8 +446,8 @@ func (p *Parlia) verifyVoteAttestation(chain consensus.ChainHeaderReader, header
 	}
 
 	// The snapshot should be the targetNumber-1 block's snapshot.
-	if len(parents) > 2 {
-		parents = parents[:len(parents)-2]
+	if len(parents) > 1 {
+		parents = parents[:len(parents)-1]
 	} else {
 		parents = nil
 	}
@@ -614,6 +614,9 @@ func (p *Parlia) verifyCascadingFields(chain consensus.ChainHeaderReader, header
 }
 
 // snapshot retrieves the authorization snapshot at a given point in time.
+// !!! be carefull
+// the block with `number` and `hash` is just the last element of `parents`,
+// unlike other interfaces such as verifyCascadingFields, `parents` are real parents
 func (p *Parlia) snapshot(chain consensus.ChainHeaderReader, number uint64, hash common.Hash, parents []*types.Header) (*Snapshot, error) {
 	// Search for a snapshot in memory or on disk for checkpoints
 	var (


### PR DESCRIPTION
### Description

func (p *Parlia) snapshot(chain consensus.ChainHeaderReader, number uint64, hash common.Hash, parents []*types.Header) (*Snapshot, error)

if parents is not nil
the  block with `number`(input param)  is parents[len(parents)-1], according to codes of function snapshot
unlike other interfaces, such as  
func (p *Parlia) verifyCascadingFields(chain consensus.ChainHeaderReader, header *types.Header, parents []*types.Header)
the block with `header.number`(input param)  is the son of parents[len(parents)-1]

this bug will lead to fail to VerifyHeaders

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
