### PR TITLE
state expiry: add state expiry hard forks and epoch compute.

### DIFF
--- a/core/types/state_epoch.go
+++ b/core/types/state_epoch.go
@@ -1,0 +1,31 @@
+package types
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/params"
+	"math/big"
+)
+
+var (
+	// EpochPeriod indicates the state rotate epoch block length
+	EpochPeriod = big.NewInt(7_008_000)
+)
+
+// GetCurrentEpoch computes the current state epoch by hard fork and block number
+// state epoch will indicate if the state is accessible or expiry.
+// Before ClaudeBlock indicates state epoch0.
+// ClaudeBlock indicates start state epoch1.
+// ElwoodBlock indicates start state epoch2 and start epoch rotate by EpochPeriod.
+// When N>=2 and epochN started, epoch(N-2)'s state will expire.
+func GetCurrentEpoch(config *params.ChainConfig, blockNumber *big.Int) *big.Int {
+	if config.IsElwood(blockNumber) {
+		ret := new(big.Int).Sub(blockNumber, config.ElwoodBlock)
+		ret.Div(ret, EpochPeriod)
+		ret.Add(ret, common.Big2)
+		return ret
+	} else if config.IsClaude(blockNumber) {
+		return common.Big1
+	} else {
+		return common.Big0
+	}
+}

--- a/core/types/state_epoch_test.go
+++ b/core/types/state_epoch_test.go
@@ -1,0 +1,98 @@
+package types
+
+import (
+	"github.com/ethereum/go-ethereum/params"
+	"github.com/stretchr/testify/assert"
+	"math/big"
+	"testing"
+)
+
+func TestStateForkConfig(t *testing.T) {
+	temp := &params.ChainConfig{}
+	assert.NoError(t, temp.CheckConfigForkOrder())
+
+	temp = &params.ChainConfig{
+		ClaudeBlock: big.NewInt(1),
+	}
+	assert.NoError(t, temp.CheckConfigForkOrder())
+
+	temp = &params.ChainConfig{
+		ElwoodBlock: big.NewInt(1),
+	}
+	assert.Error(t, temp.CheckConfigForkOrder())
+
+	temp = &params.ChainConfig{
+		ClaudeBlock: big.NewInt(0),
+		ElwoodBlock: big.NewInt(0),
+	}
+	assert.Error(t, temp.CheckConfigForkOrder())
+
+	temp = &params.ChainConfig{
+		ClaudeBlock: big.NewInt(10000),
+		ElwoodBlock: big.NewInt(10000),
+	}
+	assert.Error(t, temp.CheckConfigForkOrder())
+
+	temp = &params.ChainConfig{
+		ClaudeBlock: big.NewInt(2),
+		ElwoodBlock: big.NewInt(1),
+	}
+	assert.Error(t, temp.CheckConfigForkOrder())
+
+	temp = &params.ChainConfig{
+		ClaudeBlock: big.NewInt(0),
+		ElwoodBlock: big.NewInt(1),
+	}
+	assert.Error(t, temp.CheckConfigForkOrder())
+
+	temp = &params.ChainConfig{
+		ClaudeBlock: big.NewInt(10000),
+		ElwoodBlock: big.NewInt(10001),
+	}
+	assert.NoError(t, temp.CheckConfigForkOrder())
+}
+
+func TestSimpleStateEpoch(t *testing.T) {
+	temp := &params.ChainConfig{
+		ClaudeBlock: big.NewInt(10000),
+		ElwoodBlock: big.NewInt(20000),
+	}
+	assert.NoError(t, temp.CheckConfigForkOrder())
+
+	assert.Equal(t, big.NewInt(0), GetCurrentEpoch(temp, big.NewInt(0)))
+	assert.Equal(t, big.NewInt(0), GetCurrentEpoch(temp, big.NewInt(1000)))
+	assert.Equal(t, big.NewInt(1), GetCurrentEpoch(temp, big.NewInt(10000)))
+	assert.Equal(t, big.NewInt(1), GetCurrentEpoch(temp, big.NewInt(19999)))
+	assert.Equal(t, big.NewInt(2), GetCurrentEpoch(temp, big.NewInt(20000)))
+	assert.Equal(t, big.NewInt(3), GetCurrentEpoch(temp, new(big.Int).Add(big.NewInt(20000), EpochPeriod)))
+	assert.Equal(t, big.NewInt(102), GetCurrentEpoch(temp, new(big.Int).Add(big.NewInt(20000), new(big.Int).Mul(big.NewInt(100), EpochPeriod))))
+}
+
+func TestNoZeroStateEpoch(t *testing.T) {
+	temp := &params.ChainConfig{
+		ClaudeBlock: big.NewInt(1),
+		ElwoodBlock: big.NewInt(2),
+	}
+	assert.NoError(t, temp.CheckConfigForkOrder())
+
+	assert.Equal(t, big.NewInt(0), GetCurrentEpoch(temp, big.NewInt(0)))
+	assert.Equal(t, big.NewInt(1), GetCurrentEpoch(temp, big.NewInt(1)))
+	assert.Equal(t, big.NewInt(2), GetCurrentEpoch(temp, big.NewInt(2)))
+	assert.Equal(t, big.NewInt(2), GetCurrentEpoch(temp, big.NewInt(10000)))
+	assert.Equal(t, big.NewInt(3), GetCurrentEpoch(temp, new(big.Int).Add(big.NewInt(2), EpochPeriod)))
+	assert.Equal(t, big.NewInt(102), GetCurrentEpoch(temp, new(big.Int).Add(big.NewInt(2), new(big.Int).Mul(big.NewInt(100), EpochPeriod))))
+}
+
+func TestNearestStateEpoch(t *testing.T) {
+	temp := &params.ChainConfig{
+		ClaudeBlock: big.NewInt(10000),
+		ElwoodBlock: big.NewInt(10001),
+	}
+	assert.NoError(t, temp.CheckConfigForkOrder())
+
+	assert.Equal(t, big.NewInt(0), GetCurrentEpoch(temp, big.NewInt(0)))
+	assert.Equal(t, big.NewInt(1), GetCurrentEpoch(temp, big.NewInt(10000)))
+	assert.Equal(t, big.NewInt(2), GetCurrentEpoch(temp, big.NewInt(10001)))
+	assert.Equal(t, big.NewInt(3), GetCurrentEpoch(temp, new(big.Int).Add(big.NewInt(10001), EpochPeriod)))
+	assert.Equal(t, big.NewInt(102), GetCurrentEpoch(temp, new(big.Int).Add(big.NewInt(10001), new(big.Int).Mul(big.NewInt(100), EpochPeriod))))
+}

--- a/params/config.go
+++ b/params/config.go
@@ -299,6 +299,8 @@ var (
 		NanoBlock:           big.NewInt(21962149),
 		MoranBlock:          big.NewInt(22107423),
 		GibbsBlock:          big.NewInt(23846001),
+		//ClaudeBlock:         big.NewInt(-), // enable state expiry hard fork1 on mainNet
+		//ElwoodBlock:         big.NewInt(-),
 
 		Parlia: &ParliaConfig{
 			Period: 3,
@@ -325,6 +327,8 @@ var (
 		GibbsBlock:          big.NewInt(22800220),
 		NanoBlock:           big.NewInt(23482428),
 		MoranBlock:          big.NewInt(23603940),
+		//ClaudeBlock:         big.NewInt(-), // enable state expiry hard fork1 on testnet
+		//ElwoodBlock:         big.NewInt(-),
 		Parlia: &ParliaConfig{
 			Period: 3,
 			Epoch:  200,
@@ -350,6 +354,8 @@ var (
 		GibbsBlock:          big.NewInt(400),
 		NanoBlock:           nil,
 		MoranBlock:          nil,
+		//ClaudeBlock:         big.NewInt(-), // enable state expiry hard fork1 on QA net
+		//ElwoodBlock:         big.NewInt(-),
 
 		Parlia: &ParliaConfig{
 			Period: 3,
@@ -378,6 +384,8 @@ var (
 		GibbsBlock:          big.NewInt(0),
 		NanoBlock:           nil,
 		MoranBlock:          nil,
+		ClaudeBlock:         big.NewInt(0), // enable state expiry hard fork1 on yolo test net
+		ElwoodBlock:         big.NewInt(0),
 		MuirGlacierBlock:    nil,
 		BerlinBlock:         nil, // Don't enable Berlin directly, we're YOLOing it
 		YoloV3Block:         big.NewInt(0),
@@ -392,16 +400,16 @@ var (
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), new(EthashConfig), nil, nil}
+	AllEthashProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), new(EthashConfig), nil, nil}
 
 	// AllCliqueProtocolChanges contains every protocol change (EIPs) introduced
 	// and accepted by the Ethereum core developers into the Clique consensus.
 	//
 	// This configuration is intentionally not using keyed fields to force anyone
 	// adding flags to the config to also have to set these fields.
-	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, big.NewInt(0), nil, nil, nil, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, nil}
+	AllCliqueProtocolChanges = &ChainConfig{big.NewInt(1337), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, big.NewInt(0), nil, nil, nil, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, nil, nil, &CliqueConfig{Period: 0, Epoch: 30000}, nil}
 
-	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, new(EthashConfig), nil, nil}
+	TestChainConfig = &ChainConfig{big.NewInt(1), big.NewInt(0), nil, false, big.NewInt(0), common.Hash{}, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), big.NewInt(0), nil, nil, nil, new(EthashConfig), nil, nil}
 	TestRules       = TestChainConfig.Rules(new(big.Int), false)
 )
 
@@ -497,6 +505,8 @@ type ChainConfig struct {
 	GibbsBlock      *big.Int `json:"gibbsBlock,omitempty" toml:",omitempty"`      // gibbsBlock switch block (nil = no fork, 0 = already activated)
 	NanoBlock       *big.Int `json:"nanoBlock,omitempty" toml:",omitempty"`       // nanoBlock switch block (nil = no fork, 0 = already activated)
 	MoranBlock      *big.Int `json:"moranBlock,omitempty" toml:",omitempty"`      // moranBlock switch block (nil = no fork, 0 = already activated)
+	ClaudeBlock     *big.Int `json:"claudeBlock,omitempty" toml:",omitempty"`     // claudeBlock switch block (nil = no fork, 0 = already activated)
+	ElwoodBlock     *big.Int `json:"elwoodBlock,omitempty" toml:",omitempty"`     // elwoodBlock switch block (nil = no fork, 0 = already activated)
 
 	// Various consensus engines
 	Ethash *EthashConfig `json:"ethash,omitempty" toml:",omitempty"`
@@ -547,7 +557,7 @@ func (c *ChainConfig) String() string {
 	default:
 		engine = "unknown"
 	}
-	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Ramanujan: %v, Niels: %v, MirrorSync: %v, Bruno: %v, Berlin: %v, YOLO v3: %v, CatalystBlock: %v, London: %v, ArrowGlacier: %v, MergeFork:%v, Euler: %v, Gibbs: %v, Nano: %v, Moran: %v, Engine: %v}",
+	return fmt.Sprintf("{ChainID: %v Homestead: %v DAO: %v DAOSupport: %v EIP150: %v EIP155: %v EIP158: %v Byzantium: %v Constantinople: %v Petersburg: %v Istanbul: %v, Muir Glacier: %v, Ramanujan: %v, Niels: %v, MirrorSync: %v, Bruno: %v, Berlin: %v, YOLO v3: %v, CatalystBlock: %v, London: %v, ArrowGlacier: %v, MergeFork:%v, Euler: %v, Gibbs: %v, Nano: %v, Moran: %v, Claude: %v, Elwood: %v, Engine: %v}",
 		c.ChainID,
 		c.HomesteadBlock,
 		c.DAOForkBlock,
@@ -574,6 +584,8 @@ func (c *ChainConfig) String() string {
 		c.GibbsBlock,
 		c.NanoBlock,
 		c.MoranBlock,
+		c.ClaudeBlock,
+		c.ElwoodBlock,
 		engine,
 	)
 }
@@ -729,6 +741,22 @@ func (c *ChainConfig) IsOnMoran(num *big.Int) bool {
 	return configNumEqual(c.MoranBlock, num)
 }
 
+func (c *ChainConfig) IsClaude(num *big.Int) bool {
+	return isForked(c.ClaudeBlock, num)
+}
+
+func (c *ChainConfig) IsOnClaude(num *big.Int) bool {
+	return configNumEqual(c.ClaudeBlock, num)
+}
+
+func (c *ChainConfig) IsElwood(num *big.Int) bool {
+	return isForked(c.ElwoodBlock, num)
+}
+
+func (c *ChainConfig) IsOnElwood(num *big.Int) bool {
+	return configNumEqual(c.ElwoodBlock, num)
+}
+
 // CheckCompatible checks whether scheduled fork transitions have been imported
 // with a mismatching chain configuration.
 func (c *ChainConfig) CheckCompatible(newcfg *ChainConfig, height uint64) *ConfigCompatError {
@@ -780,6 +808,25 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 			lastFork = cur
 		}
 	}
+
+	// check state expiry's hard forks
+	if c.ClaudeBlock != nil || c.ElwoodBlock != nil {
+		if c.ClaudeBlock == nil {
+			return fmt.Errorf("unsupported state expiry fork number ClaudeBlock: %v ElwoodBlock %v",
+				c.ClaudeBlock, c.ElwoodBlock)
+		}
+
+		if c.ClaudeBlock.Cmp(common.Big0) <= 0 {
+			return fmt.Errorf("unsupported state expiry fork number ClaudeBlock: %v",
+				c.ClaudeBlock)
+		}
+
+		if c.ElwoodBlock != nil && c.ClaudeBlock.Cmp(c.ElwoodBlock) >= 0 {
+			return fmt.Errorf("unsupported state expiry fork number ClaudeBlock: %v ElwoodBlock %v",
+				c.ClaudeBlock, c.ElwoodBlock)
+		}
+	}
+
 	return nil
 }
 
@@ -856,6 +903,12 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, head *big.Int) *Confi
 	}
 	if isForkIncompatible(c.MoranBlock, newcfg.MoranBlock, head) {
 		return newCompatError("moran fork block", c.MoranBlock, newcfg.MoranBlock)
+	}
+	if isForkIncompatible(c.ClaudeBlock, newcfg.ClaudeBlock, head) {
+		return newCompatError("claude fork block", c.ClaudeBlock, newcfg.ClaudeBlock)
+	}
+	if isForkIncompatible(c.ElwoodBlock, newcfg.ElwoodBlock, head) {
+		return newCompatError("elwood fork block", c.ElwoodBlock, newcfg.ElwoodBlock)
 	}
 	return nil
 }


### PR DESCRIPTION
### Description

There are two hard forks, the first hard fork support new tx, epoch0, epoch1, second hard fork support epoch rotate. we could delay state expiry, fix issues, and upgrade features between two hard forks.

`STATE_EXPIRY_HARDFORK1_BLOCKNUM` indicates start epoch1, `STATE_EXPIRY_HARDFORK2_BLOCKNUM` indicates start epoch2 and start epoch rotate by EpochPeriod.

Epoch definition, calculate block epoch by:

```go
func getCurrentEpoch(block uint64) uint64 {
    if block < STATE_EXPIRY_HARDFORK1_BLOCKNUM {
        return 0
    } else if block < STATE_EXPIRY_HARDFORK2_BLOCKNUM {
        return 1
    } else {
        return (block - STATE_EXPIRY_HARDFORK2_BLOCKNUM) / EpochPeriod + 2
    }
}
```

EpochPeriod = 7,008,000.

When merge furture Verkle Tree, from N epoch for special upgrade.

### Changes

Notable changes: 
* hard fork: add state expiry hard forks; 
* types: add state epoch;

types: add state epoch;
