### PR TITLE
modify fork choice to prefer higher justified block number

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -152,8 +152,8 @@ type PoSA interface {
 	EnoughDistance(chain ChainReader, header *types.Header) bool
 	IsLocalBlock(header *types.Header) bool
 	AllowLightProcess(chain ChainReader, currentHeader *types.Header) bool
-	GetJustifiedHeader(chain ChainHeaderReader, header *types.Header) *types.Header
-	GetFinalizedHeader(chain ChainHeaderReader, header *types.Header, backward uint64) *types.Header
+	GetJustifiedNumberAndHash(chain ChainHeaderReader, header *types.Header) (uint64, common.Hash, error)
+	GetFinalizedHeader(chain ChainHeaderReader, header *types.Header) *types.Header
 	VerifyVote(chain ChainHeaderReader, vote *types.VoteEnvelope) error
 	IsActiveValidatorAt(chain ChainHeaderReader, header *types.Header) bool
 }

--- a/core/vote/vote_pool.go
+++ b/core/vote/vote_pool.go
@@ -23,7 +23,7 @@ const (
 	voteBufferForPut = 256
 	// for simplicity, both boundary will be included, so votes in the range [currentBlockNum-256,currentBlockNum+11] will be stored
 	lowerLimitOfVoteBlockNumber = 256
-	upperLimitOfVoteBlockNumber = 11
+	upperLimitOfVoteBlockNumber = 11 // refer to fetcher.maxUncleDist
 
 	chainHeadChanSize = 10 // chainHeadChanSize is the size of channel listening to ChainHeadEvent.
 )

--- a/core/vote/vote_pool_test.go
+++ b/core/vote/vote_pool_test.go
@@ -69,12 +69,16 @@ type mockInvalidPOSA struct {
 	consensus.PoSA
 }
 
-func (p *mockPOSA) GetJustifiedHeader(chain consensus.ChainHeaderReader, header *types.Header) *types.Header {
-	return chain.GetHeaderByHash(header.ParentHash)
+func (p *mockPOSA) GetJustifiedNumberAndHash(chain consensus.ChainHeaderReader, header *types.Header) (uint64, common.Hash, error) {
+	parentHeader := chain.GetHeaderByHash(header.ParentHash)
+	if parentHeader == nil {
+		return 0, common.Hash{}, fmt.Errorf("unexpected error")
+	}
+	return parentHeader.Number.Uint64(), parentHeader.Hash(), nil
 }
 
-func (p *mockInvalidPOSA) GetJustifiedHeader(chain consensus.ChainHeaderReader, header *types.Header) *types.Header {
-	return nil
+func (p *mockInvalidPOSA) GetJustifiedNumberAndHash(chain consensus.ChainHeaderReader, header *types.Header) (uint64, common.Hash, error) {
+	return 0, common.Hash{}, fmt.Errorf("not supported")
 }
 
 func (m *mockPOSA) VerifyVote(chain consensus.ChainHeaderReader, vote *types.VoteEnvelope) error {

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -207,19 +207,20 @@ func (ec *Client) GetRootByDiffHash(ctx context.Context, blockNr *big.Int, block
 	return &result, err
 }
 
-// GetJustifiedHeader returns the highest justified header before a specific block number. If number is nil, the
-// latest justified block header is returned.
-func (ec *Client) GetJustifiedHeader(ctx context.Context, blockNumber *big.Int) (*types.Header, error) {
-	var head *types.Header
-	err := ec.c.CallContext(ctx, &head, "eth_getJustifiedHeader", toBlockNumArg(blockNumber))
-	if err == nil && head == nil {
-		err = ethereum.NotFound
+// GetJustifiedNumberAndHash returns the highest justified block's number and hash on the branch including and before the input block.
+// If number is nil, the latest justified block header is returned.
+func (ec *Client) GetJustifiedNumberAndHash(ctx context.Context, blockNumber *big.Int) (uint64, common.Hash, error) {
+	var justifiedBlockNumber uint64
+	var justifiedBlockHash common.Hash
+	err := ec.c.CallContext(ctx, &[]interface{}{&justifiedBlockNumber, &justifiedBlockHash}, "eth_getJustifiedNumberAndHash", toBlockNumArg(blockNumber))
+	if err == nil && justifiedBlockHash == (common.Hash{}) {
+		err = errors.New("unexpected error")
 	}
-	return head, err
+	return justifiedBlockNumber, justifiedBlockHash, err
 }
 
-// GetFinalizedHeader returns the highest finalized block header before a specific block number. If header is nil, the
-// latest finalized block header is returned.
+// GetFinalizedHeader returns the highest finalized block header.
+// If header is nil, the latest finalized block header is returned.
 func (ec *Client) GetFinalizedHeader(ctx context.Context, blockNumber *big.Int) (*types.Header, error) {
 	var head *types.Header
 	err := ec.c.CallContext(ctx, &head, "eth_getFinalizedHeader", toBlockNumArg(blockNumber))


### PR DESCRIPTION
### Description

modify fork choice to improve security, details as following:

1. reimplement reorgNeededWithFastFinality by selecting higher justified block firstly,
   and move it into forkchoice.go to avoid implement it twice
2. remove all naturally justified info, and fetch justified block number and hash 
	from snapshot of consensus by using new func GetJustifiedNumberAndHash
3. change func signature of GetFinalizedHeader by removing input param `backward`,
	use types.NaturallyFinalizedDist internally
4. repair test cases in parlia_test.go
	a. finalized block and justified block are always same, it's wrong, now fixed
	b. use new reorg logic
5. export GetJustifiedNumberAndHash as api instead of GetJustifiedHeader


### Rationale


### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
