### PR TITLE
improve code of bsc p2p protocol

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -54,6 +54,7 @@ const (
 	// voteChanSize is the size of channel listening to NewVotesEvent.
 	voteChanSize = 256
 
+	// deltaTdThreshold is the threshold of TD difference for peers to broadcast votes.
 	deltaTdThreshold = 20
 )
 
@@ -804,7 +805,7 @@ func (h *handler) BroadcastVote(vote *types.VoteEnvelope) {
 	for _, peer := range peers {
 		_, peerTD := peer.Head()
 		deltaTD := new(big.Int).Abs(new(big.Int).Sub(currentTD, peerTD))
-		if deltaTD.Cmp(big.NewInt(deltaTdThreshold)) < 1 {
+		if deltaTD.Cmp(big.NewInt(deltaTdThreshold)) < 1 && peer.bscExt != nil {
 			voteMap[peer] = vote
 		}
 	}
@@ -813,9 +814,7 @@ func (h *handler) BroadcastVote(vote *types.VoteEnvelope) {
 		directPeers++
 		directCount += 1
 		votes := []*types.VoteEnvelope{_vote}
-		if peer.bscExt != nil {
-			peer.bscExt.AsyncSendVotes(votes)
-		}
+		peer.bscExt.AsyncSendVotes(votes)
 	}
 	log.Debug("Vote broadcast", "vote packs", directPeers, "broadcast vote", directCount)
 }

--- a/eth/peer.go
+++ b/eth/peer.go
@@ -42,7 +42,7 @@ type ethPeer struct {
 	snapExt  *snapPeer // Satellite `snap` connection
 	diffExt  *diffPeer
 	trustExt *trustPeer
-	bscExt   *bscPeer
+	bscExt   *bscPeer // Satellite `bsc` connection
 
 	syncDrop *time.Timer   // Connection dropper if `eth` sync progress isn't validated in time
 	snapWait chan struct{} // Notification channel for snap connections

--- a/eth/protocols/bsc/handler.go
+++ b/eth/protocols/bsc/handler.go
@@ -131,9 +131,7 @@ func handleVotes(backend Backend, msg Decoder, peer *Peer) error {
 		return fmt.Errorf("%w: message %v: %v", errDecode, msg, err)
 	}
 	// Schedule all the unknown hashes for retrieval
-	for _, vote := range ann.Votes {
-		peer.markVote(vote.Hash())
-	}
+	peer.markVotes(ann.Votes)
 	return backend.Handle(peer, ann)
 }
 

--- a/eth/protocols/bsc/handshake.go
+++ b/eth/protocols/bsc/handshake.go
@@ -28,7 +28,7 @@ func (p *Peer) Handshake() error {
 		})
 	})
 	gopool.Submit(func() {
-		errc <- p.readBscCap(&cap)
+		errc <- p.readCap(&cap)
 	})
 	timeout := time.NewTimer(handshakeTimeout)
 	defer timeout.Stop()
@@ -45,8 +45,8 @@ func (p *Peer) Handshake() error {
 	return nil
 }
 
-// readBscCap reads the remote handshake message.
-func (p *Peer) readBscCap(cap *BscCapPacket) error {
+// readCap reads the remote handshake message.
+func (p *Peer) readCap(cap *BscCapPacket) error {
 	msg, err := p.rw.ReadMsg()
 	if err != nil {
 		return err

--- a/eth/sync.go
+++ b/eth/sync.go
@@ -60,6 +60,7 @@ func (h *handler) syncTransactions(p *eth.Peer) {
 	p.AsyncSendPooledTransactionHashes(hashes)
 }
 
+// syncVotes starts sending all currently pending votes to the given peer.
 func (h *handler) syncVotes(p *bscPeer) {
 	votes := h.votepool.GetVotes()
 	if len(votes) == 0 {


### PR DESCRIPTION
### Description

no logic change, just some small improvements

### Rationale

1.  add some missing comment
2. BroadcastVote: more accurate for cal directPeers and directCount
3. markVote --> markVotes, improve efficiency
4. readBscCap-->readCap, in package bsc, bsc as default, so readCap is better
5. knownCache.Contains-->knownCache.contains
    knownCache.Add-->knownCache.add
    they are not used out of package
    
    delete knownCache.Cardinality, useless

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
