### PR TITLE
fix BroadcastVote when GetTd, may lead to panic

### DIFF
--- a/eth/handler.go
+++ b/eth/handler.go
@@ -799,9 +799,11 @@ func (h *handler) BroadcastVote(vote *types.VoteEnvelope) {
 
 	// Broadcast vote to a batch of peers not knowing about it
 	peers := h.peers.peersWithoutVote(vote.Hash())
+	headBlock := h.chain.CurrentBlock()
+	currentTD := h.chain.GetTd(headBlock.Hash(), headBlock.NumberU64())
 	for _, peer := range peers {
 		_, peerTD := peer.Head()
-		deltaTD := new(big.Int).Abs(new(big.Int).Sub(h.chain.GetTd(h.chain.CurrentHeader().Hash(), h.chain.CurrentBlock().NumberU64()), peerTD))
+		deltaTD := new(big.Int).Abs(new(big.Int).Sub(currentTD, peerTD))
 		if deltaTD.Cmp(big.NewInt(deltaTdThreshold)) < 1 {
 			voteMap[peer] = vote
 		}


### PR DESCRIPTION
### Description

fix BroadcastVote when GetTd, may lead to panic

### Rationale
Raw code:
   deltaTD := new(big.Int).Abs(new(big.Int).Sub(h.chain.GetTd(h.chain.CurrentHeader().Hash(), h.chain.CurrentBlock().NumberU64()), peerTD))
Issue:
   h.chain.CurrentHeader().Hash() and h.chain.CurrentBlock().NumberU64() may pointer to different block
   so the first param of Sub may be nil
### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
