### PR TITLE
fix mini bug for markVotes

### DIFF
--- a/eth/handler_bsc_test.go
+++ b/eth/handler_bsc_test.go
@@ -263,9 +263,8 @@ func testRecvVotes(t *testing.T, protocol uint) {
 		},
 	}
 
-	if err := remoteBsc.SendVotes([]*types.VoteEnvelope{&vote}); err != nil {
-		t.Fatalf("failed to send vote: %v", err)
-	}
+	remoteBsc.AsyncSendVotes([]*types.VoteEnvelope{&vote})
+	time.Sleep(100 * time.Millisecond)
 	select {
 	case event := <-votesCh:
 		if event.Vote.Hash() != vote.Hash() {


### PR DESCRIPTION
### Description

1. in func markVotes 
before adding hash to set, we should check if hash is already contained
otherwise, may lead to evict item, and add item already contained again
2. remove markVotes in AsyncSendVotes
 because, sendVotes will be called following AsyncSendVotes
 no need to double markVotes.

### Rationale

tell us why we need these changes...

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
