### PR TITLE
fix vote attestation security flaw and enable new fork choice rule after Lynn fork

### DIFF
--- a/consensus/parlia/snapshot.go
+++ b/consensus/parlia/snapshot.go
@@ -174,10 +174,6 @@ func (s *Snapshot) isMajorityFork(forkHash string) bool {
 }
 
 func (s *Snapshot) updateAttestation(header *types.Header, chainConfig *params.ChainConfig, parliaConfig *params.ParliaConfig) {
-	if !chainConfig.IsBoneh(header.Number) {
-		return
-	}
-
 	// The attestation should have been checked in verify header, update directly
 	attestation, _ := getVoteAttestationFromHeader(header, chainConfig, parliaConfig)
 	if attestation == nil {
@@ -193,7 +189,7 @@ func (s *Snapshot) updateAttestation(header *types.Header, chainConfig *params.C
 	}
 }
 
-func (s *Snapshot) apply(headers []*types.Header, chain consensus.ChainHeaderReader, parents []*types.Header, chainConfig *params.ChainConfig) (*Snapshot, error) {
+func (s *Snapshot) apply(headers []*types.Header, chain consensus.ChainHeaderReader, parents []*types.Header, chainConfig *params.ChainConfig, verifiedAttestations map[common.Hash]struct{}) (*Snapshot, error) {
 	// Allow passing in no headers for cleaner code
 	if len(headers) == 0 {
 		return s, nil
@@ -283,7 +279,12 @@ func (s *Snapshot) apply(headers []*types.Header, chain consensus.ChainHeaderRea
 				}
 			}
 		}
-		snap.updateAttestation(header, chainConfig, s.config)
+
+		_, voteAssestationNoErr := verifiedAttestations[header.Hash()]
+		if (chainConfig.IsBoneh(header.Number) && voteAssestationNoErr) || chainConfig.IsLynn(header.Number) {
+			snap.updateAttestation(header, chainConfig, s.config)
+		}
+
 		snap.RecentForkHashes[number] = hex.EncodeToString(header.Extra[extraVanity-nextForkHashSize : extraVanity])
 	}
 	snap.Number += uint64(len(headers))

--- a/core/forkchoice.go
+++ b/core/forkchoice.go
@@ -117,9 +117,18 @@ func (f *ForkChoice) reorgNeeded(current *types.Header, header *types.Header) (b
 // ReorgNeededWithFastFinality compares justified block numbers firstly, backoff to compare tds when equal
 func (f *ForkChoice) ReorgNeededWithFastFinality(current *types.Header, header *types.Header) (bool, error) {
 	_, ok := f.chain.Engine().(consensus.PoSA)
-	justifiedNumber := f.chain.GetJustifiedNumber(header)
-	curJustifiedNumber := f.chain.GetJustifiedNumber(current)
-	if !ok || justifiedNumber == curJustifiedNumber {
+	if !ok {
+		return f.reorgNeeded(current, header)
+	}
+
+	justifiedNumber, curJustifiedNumber := uint64(0), uint64(0)
+	if f.chain.Config().IsLynn(header.Number) {
+		justifiedNumber = f.chain.GetJustifiedNumber(header)
+	}
+	if f.chain.Config().IsLynn(current.Number) {
+		curJustifiedNumber = f.chain.GetJustifiedNumber(current)
+	}
+	if justifiedNumber == curJustifiedNumber {
 		return f.reorgNeeded(current, header)
 	}
 


### PR DESCRIPTION
### Description
1. snapshot of consensus may update invalid vote attestation before Lynn fork
2. new fork choice rule enabled after Boneh fork, which is expected after Lynn fork

### Rationale
1. before Lynn fork, we should only update valid vote attestation, check it before updating,
    after Lynn fork, we don't need to check it any more, 
    because header with invalid vote attestation (nill is legal here) will be rejected when imported, 
    outputting warn log at the same time.
2. delay new fork choice rule after Lynn fork

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
