### PR TITLE
fix vote attestation security flaw and enable new fork choice rule after Lynn fork

### DIFF
--- a/core/forkchoice.go
+++ b/core/forkchoice.go
@@ -117,9 +117,18 @@ func (f *ForkChoice) reorgNeeded(current *types.Header, header *types.Header) (b
 // ReorgNeededWithFastFinality compares justified block numbers firstly, backoff to compare tds when equal
 func (f *ForkChoice) ReorgNeededWithFastFinality(current *types.Header, header *types.Header) (bool, error) {
 	_, ok := f.chain.Engine().(consensus.PoSA)
-	justifiedNumber := f.chain.GetJustifiedNumber(header)
-	curJustifiedNumber := f.chain.GetJustifiedNumber(current)
-	if !ok || justifiedNumber == curJustifiedNumber {
+	if !ok {
+		return f.reorgNeeded(current, header)
+	}
+
+	justifiedNumber, curJustifiedNumber := uint64(0), uint64(0)
+	if f.chain.Config().IsLynn(header.Number) {
+		justifiedNumber = f.chain.GetJustifiedNumber(header)
+	}
+	if f.chain.Config().IsLynn(current.Number) {
+		curJustifiedNumber = f.chain.GetJustifiedNumber(current)
+	}
+	if justifiedNumber == curJustifiedNumber {
 		return f.reorgNeeded(current, header)
 	}
 


### PR DESCRIPTION
### Description
1. snapshot of consensus may update invalid vote attestation before Lynn fork
2. new fork choice rule enabled after Boneh fork, which is expected after Lynn fork

### Rationale
1. before Lynn fork, we should only update valid vote attestation, check it before updating,
    after Lynn fork, we don't need to check it any more, 
    because header with invalid vote attestation (nill is legal here) will be rejected when imported, 
    outputting warn log at the same time.
2. delay new fork choice rule after Lynn fork

### Example

add an example CLI or API response...

### Changes

Notable changes: 
* add each change in a bullet point here
* ...
