### PR TITLE
enhance GetBlockByNumber by supporting 'safe' and 'finalized', following Geth

### DIFF
--- a/core/blockchain_reader.go
+++ b/core/blockchain_reader.go
@@ -42,6 +42,36 @@ func (bc *BlockChain) CurrentBlock() *types.Block {
 	return bc.currentBlock.Load().(*types.Block)
 }
 
+// CurrentFinalBlock retrieves the current finalized block of the canonical
+// chain. The block is retrieved from the blockchain's internal cache.
+func (bc *BlockChain) CurrentFinalBlock() *types.Header {
+	if p, ok := bc.engine.(consensus.PoSA); ok {
+		currentHeader := bc.CurrentHeader()
+		if currentHeader == nil {
+			return nil
+		}
+		return p.GetFinalizedHeader(bc, currentHeader)
+	}
+
+	return nil
+}
+
+// CurrentSafeBlock retrieves the current safe block of the canonical
+// chain. The block is retrieved from the blockchain's internal cache.
+func (bc *BlockChain) CurrentSafeBlock() *types.Header {
+	if p, ok := bc.engine.(consensus.PoSA); ok {
+		currentHeader := bc.CurrentHeader()
+		if currentHeader == nil {
+			return nil
+		}
+		_, justifiedBlockHash, err := p.GetJustifiedNumberAndHash(bc, currentHeader)
+		if err == nil {
+			return bc.GetHeaderByHash(justifiedBlockHash)
+		}
+	}
+	return nil
+}
+
 // CurrentFastBlock retrieves the current fast-sync head block of the canonical
 // chain. The block is retrieved from the blockchain's internal cache.
 func (bc *BlockChain) CurrentFastBlock() *types.Block {

--- a/eth/api.go
+++ b/eth/api.go
@@ -282,16 +282,24 @@ func (api *PublicDebugAPI) DumpBlock(blockNr rpc.BlockNumber) (state.Dump, error
 		_, stateDb := api.eth.miner.Pending()
 		return stateDb.RawDump(opts), nil
 	}
-	var block *types.Block
+	var header *types.Header
 	if blockNr == rpc.LatestBlockNumber {
-		block = api.eth.blockchain.CurrentBlock()
+		header = api.eth.blockchain.CurrentHeader()
+	} else if blockNr == rpc.FinalizedBlockNumber {
+		header = api.eth.blockchain.CurrentFinalBlock()
+	} else if blockNr == rpc.SafeBlockNumber {
+		header = api.eth.blockchain.CurrentSafeBlock()
 	} else {
-		block = api.eth.blockchain.GetBlockByNumber(uint64(blockNr))
+		block := api.eth.blockchain.GetBlockByNumber(uint64(blockNr))
+		if block == nil {
+			return state.Dump{}, fmt.Errorf("block #%d not found", blockNr)
+		}
+		header = block.Header()
 	}
-	if block == nil {
+	if header == nil {
 		return state.Dump{}, fmt.Errorf("block #%d not found", blockNr)
 	}
-	stateDb, err := api.eth.BlockChain().StateAt(block.Root())
+	stateDb, err := api.eth.BlockChain().StateAt(header.Root)
 	if err != nil {
 		return state.Dump{}, err
 	}
@@ -370,16 +378,24 @@ func (api *PublicDebugAPI) AccountRange(blockNrOrHash rpc.BlockNumberOrHash, sta
 			// the miner and operate on those
 			_, stateDb = api.eth.miner.Pending()
 		} else {
-			var block *types.Block
+			var header *types.Header
 			if number == rpc.LatestBlockNumber {
-				block = api.eth.blockchain.CurrentBlock()
+				header = api.eth.blockchain.CurrentHeader()
+			} else if number == rpc.FinalizedBlockNumber {
+				header = api.eth.blockchain.CurrentFinalBlock()
+			} else if number == rpc.SafeBlockNumber {
+				header = api.eth.blockchain.CurrentSafeBlock()
 			} else {
-				block = api.eth.blockchain.GetBlockByNumber(uint64(number))
+				block := api.eth.blockchain.GetBlockByNumber(uint64(number))
+				if block == nil {
+					return state.IteratorDump{}, fmt.Errorf("block #%d not found", number)
+				}
+				header = block.Header()
 			}
-			if block == nil {
+			if header == nil {
 				return state.IteratorDump{}, fmt.Errorf("block #%d not found", number)
 			}
-			stateDb, err = api.eth.BlockChain().StateAt(block.Root())
+			stateDb, err = api.eth.BlockChain().StateAt(header.Root)
 			if err != nil {
 				return state.IteratorDump{}, err
 			}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -19,6 +19,7 @@ package eth
 import (
 	"context"
 	"errors"
+	"fmt"
 	"math/big"
 	"time"
 
@@ -71,7 +72,21 @@ func (b *EthAPIBackend) HeaderByNumber(ctx context.Context, number rpc.BlockNumb
 	}
 	// Otherwise resolve and return the block
 	if number == rpc.LatestBlockNumber {
-		return b.eth.blockchain.CurrentBlock().Header(), nil
+		return b.eth.blockchain.CurrentHeader(), nil
+	}
+	if number == rpc.FinalizedBlockNumber {
+		block := b.eth.blockchain.CurrentFinalBlock()
+		if block != nil {
+			return block, nil
+		}
+		return nil, errors.New("finalized block not found")
+	}
+	if number == rpc.SafeBlockNumber {
+		block := b.eth.blockchain.CurrentSafeBlock()
+		if block != nil {
+			return block, nil
+		}
+		return nil, errors.New("safe block not found")
 	}
 	return b.eth.blockchain.GetHeaderByNumber(uint64(number)), nil
 }
@@ -106,6 +121,20 @@ func (b *EthAPIBackend) BlockByNumber(ctx context.Context, number rpc.BlockNumbe
 	// Otherwise resolve and return the block
 	if number == rpc.LatestBlockNumber {
 		return b.eth.blockchain.CurrentBlock(), nil
+	}
+	if number == rpc.FinalizedBlockNumber {
+		header := b.eth.blockchain.CurrentFinalBlock()
+		if header == nil {
+			return nil, fmt.Errorf("block #%d not found", number)
+		}
+		return b.eth.blockchain.GetBlock(header.Hash(), header.Number.Uint64()), nil
+	}
+	if number == rpc.SafeBlockNumber {
+		header := b.eth.blockchain.CurrentSafeBlock()
+		if header == nil {
+			return nil, fmt.Errorf("block #%d not found", number)
+		}
+		return b.eth.blockchain.GetBlock(header.Hash(), header.Number.Uint64()), nil
 	}
 	return b.eth.blockchain.GetBlockByNumber(uint64(number)), nil
 }

--- a/eth/filters/filter.go
+++ b/eth/filters/filter.go
@@ -19,7 +19,6 @@ package filters
 import (
 	"context"
 	"errors"
-	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -150,23 +149,44 @@ func (f *Filter) Logs(ctx context.Context) ([]*types.Log, error) {
 		return nil, nil
 	}
 	var (
-		head    = header.Number.Uint64()
-		end     = uint64(f.end)
+		err     error
+		head    = header.Number.Int64()
 		pending = f.end == rpc.PendingBlockNumber.Int64()
 	)
-	if f.begin == rpc.LatestBlockNumber.Int64() {
-		f.begin = int64(head)
+	resolveSpecial := func(number int64) (int64, error) {
+		var hdr *types.Header
+		switch number {
+		case rpc.LatestBlockNumber.Int64():
+			return head, nil
+		case rpc.PendingBlockNumber.Int64():
+			// we should return head here since we've already captured
+			// that we need to get the pending logs in the pending boolean above
+			return head, nil
+		case rpc.FinalizedBlockNumber.Int64():
+			hdr, _ = f.backend.HeaderByNumber(ctx, rpc.FinalizedBlockNumber)
+			if hdr == nil {
+				return 0, errors.New("finalized header not found")
+			}
+		case rpc.SafeBlockNumber.Int64():
+			hdr, _ = f.backend.HeaderByNumber(ctx, rpc.SafeBlockNumber)
+			if hdr == nil {
+				return 0, errors.New("safe header not found")
+			}
+		default:
+			return number, nil
+		}
+		return hdr.Number.Int64(), nil
 	}
-	if f.end == rpc.LatestBlockNumber.Int64() || f.end == rpc.PendingBlockNumber.Int64() {
-		end = head
+	if f.begin, err = resolveSpecial(f.begin); err != nil {
+		return nil, err
 	}
-	if f.rangeLimit && (int64(end)-f.begin) > maxFilterBlockRange {
-		return nil, fmt.Errorf("exceed maximum block range: %d", maxFilterBlockRange)
+	if f.end, err = resolveSpecial(f.end); err != nil {
+		return nil, err
 	}
 	// Gather all indexed logs, and finish with non indexed ones
 	var (
 		logs           []*types.Log
-		err            error
+		end            = uint64(f.end)
 		size, sections = f.backend.BloomStatus()
 	)
 	if indexed := sections * size; indexed > uint64(f.begin) {

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -18,6 +18,7 @@ package filters
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"math/rand"
@@ -65,14 +66,19 @@ func (b *testBackend) HeaderByNumber(ctx context.Context, blockNr rpc.BlockNumbe
 		hash common.Hash
 		num  uint64
 	)
-	if blockNr == rpc.LatestBlockNumber {
+	switch blockNr {
+	case rpc.LatestBlockNumber:
 		hash = rawdb.ReadHeadBlockHash(b.db)
 		number := rawdb.ReadHeaderNumber(b.db, hash)
 		if number == nil {
 			return nil, nil
 		}
 		num = *number
-	} else {
+	case rpc.FinalizedBlockNumber:
+		return nil, errors.New("finalized block not found")
+	case rpc.SafeBlockNumber:
+		return nil, errors.New("safe block not found")
+	default:
 		num = uint64(blockNr)
 		hash = rawdb.ReadCanonicalHash(b.db, num)
 	}

--- a/eth/gasprice/feehistory.go
+++ b/eth/gasprice/feehistory.go
@@ -137,44 +137,68 @@ func (oracle *Oracle) processBlock(bf *blockFees, percentiles []float64) {
 // also returned if requested and available.
 // Note: an error is only returned if retrieving the head header has failed. If there are no
 // retrievable blocks in the specified range then zero block count is returned with no error.
-func (oracle *Oracle) resolveBlockRange(ctx context.Context, lastBlock rpc.BlockNumber, blocks int) (*types.Block, []*types.Receipt, uint64, int, error) {
+func (oracle *Oracle) resolveBlockRange(ctx context.Context, reqEnd rpc.BlockNumber, blocks int) (*types.Block, []*types.Receipt, uint64, int, error) {
 	var (
-		headBlock       rpc.BlockNumber
+		headBlock       *types.Header
 		pendingBlock    *types.Block
 		pendingReceipts types.Receipts
+		err             error
 	)
-	// query either pending block or head header and set headBlock
-	if lastBlock == rpc.PendingBlockNumber {
-		if pendingBlock, pendingReceipts = oracle.backend.PendingBlockAndReceipts(); pendingBlock != nil {
-			lastBlock = rpc.BlockNumber(pendingBlock.NumberU64())
-			headBlock = lastBlock - 1
-		} else {
-			// pending block not supported by backend, process until latest block
-			lastBlock = rpc.LatestBlockNumber
-			blocks--
-			if blocks == 0 {
-				return nil, nil, 0, 0, nil
-			}
-		}
+
+	// Get the chain's current head.
+	if headBlock, err = oracle.backend.HeaderByNumber(ctx, rpc.LatestBlockNumber); err != nil {
+		return nil, nil, 0, 0, err
 	}
-	if pendingBlock == nil {
-		// if pending block is not fetched then we retrieve the head header to get the head block number
-		if latestHeader, err := oracle.backend.HeaderByNumber(ctx, rpc.LatestBlockNumber); err == nil && latestHeader != nil {
-			headBlock = rpc.BlockNumber(latestHeader.Number.Uint64())
-		} else {
+	head := rpc.BlockNumber(headBlock.Number.Uint64())
+
+	// Fail if request block is beyond the chain's current head.
+	if head < reqEnd {
+		return nil, nil, 0, 0, fmt.Errorf("%w: requested %d, head %d", errRequestBeyondHead, reqEnd, head)
+	}
+
+	// Resolve block tag.
+	if reqEnd < 0 {
+		var (
+			resolved *types.Header
+			err      error
+		)
+		switch reqEnd {
+		case rpc.PendingBlockNumber:
+			if pendingBlock, pendingReceipts = oracle.backend.PendingBlockAndReceipts(); pendingBlock != nil {
+				resolved = pendingBlock.Header()
+			} else {
+				// Pending block not supported by backend, process only until latest block.
+				resolved = headBlock
+
+				// Update total blocks to return to account for this.
+				blocks--
+			}
+		case rpc.LatestBlockNumber:
+			// Retrieved above.
+			resolved = headBlock
+		case rpc.SafeBlockNumber:
+			resolved, err = oracle.backend.HeaderByNumber(ctx, rpc.SafeBlockNumber)
+		case rpc.FinalizedBlockNumber:
+			resolved, err = oracle.backend.HeaderByNumber(ctx, rpc.FinalizedBlockNumber)
+		case rpc.EarliestBlockNumber:
+			resolved, err = oracle.backend.HeaderByNumber(ctx, rpc.EarliestBlockNumber)
+		}
+		if resolved == nil || err != nil {
 			return nil, nil, 0, 0, err
 		}
+		// Absolute number resolved.
+		reqEnd = rpc.BlockNumber(resolved.Number.Uint64())
 	}
-	if lastBlock == rpc.LatestBlockNumber {
-		lastBlock = headBlock
-	} else if pendingBlock == nil && lastBlock > headBlock {
-		return nil, nil, 0, 0, fmt.Errorf("%w: requested %d, head %d", errRequestBeyondHead, lastBlock, headBlock)
+
+	// If there are no blocks to return, short circuit.
+	if blocks == 0 {
+		return nil, nil, 0, 0, nil
 	}
-	// ensure not trying to retrieve before genesis
-	if rpc.BlockNumber(blocks) > lastBlock+1 {
-		blocks = int(lastBlock + 1)
+	// Ensure not trying to retrieve before genesis.
+	if uint64(reqEnd+1) < uint64(blocks) {
+		blocks = int(reqEnd + 1)
 	}
-	return pendingBlock, pendingReceipts, uint64(lastBlock), blocks, nil
+	return pendingBlock, pendingReceipts, uint64(reqEnd), blocks, nil
 }
 
 // FeeHistory returns data relevant for fee estimation based on the specified range of blocks.

--- a/eth/gasprice/feehistory_test.go
+++ b/eth/gasprice/feehistory_test.go
@@ -50,6 +50,8 @@ func TestFeeHistory(t *testing.T) {
 		{false, 1000, 1000, 2, rpc.PendingBlockNumber, nil, 32, 1, nil},
 		{true, 1000, 1000, 2, rpc.PendingBlockNumber, nil, 32, 2, nil},
 		{true, 1000, 1000, 2, rpc.PendingBlockNumber, []float64{0, 10}, 32, 2, nil},
+		// {false, 1000, 1000, 2, rpc.FinalizedBlockNumber, []float64{0, 10}, 24, 2, nil},
+		// {false, 1000, 1000, 2, rpc.SafeBlockNumber, []float64{0, 10}, 24, 2, nil},
 	}
 	for i, c := range cases {
 		config := Config{

--- a/ethclient/gethclient/gethclient.go
+++ b/ethclient/gethclient/gethclient.go
@@ -188,6 +188,14 @@ func toBlockNumArg(number *big.Int) string {
 	if number.Cmp(pending) == 0 {
 		return "pending"
 	}
+	finalized := big.NewInt(int64(rpc.FinalizedBlockNumber))
+	if number.Cmp(finalized) == 0 {
+		return "finalized"
+	}
+	safe := big.NewInt(int64(rpc.SafeBlockNumber))
+	if number.Cmp(safe) == 0 {
+		return "safe"
+	}
 	return hexutil.EncodeBig(number)
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1328,53 +1328,6 @@ func (s *PublicBlockChainAPI) GetDiffAccountsWithScope(ctx context.Context, bloc
 	return result, err
 }
 
-// GetJustifiedNumberAndHash returns the highest justified block's number and hash on the branch including and before the input block.
-func (s *PublicBlockChainAPI) GetJustifiedNumberAndHash(ctx context.Context, blockNrOrHash *rpc.BlockNumberOrHash) (uint64, common.Hash, error) {
-	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
-	if blockNrOrHash != nil {
-		bNrOrHash = *blockNrOrHash
-	}
-
-	// Retrieve the block to act as the gas ceiling
-	header, err := s.b.HeaderByNumberOrHash(ctx, bNrOrHash)
-	if err != nil {
-		return 0, common.Hash{}, err
-	}
-	if header == nil {
-		return 0, common.Hash{}, errors.New("block header not found")
-	}
-
-	if posa, ok := s.b.Engine().(consensus.PoSA); ok {
-		return posa.GetJustifiedNumberAndHash(s.b.Chain(), header)
-	}
-
-	return 0, common.Hash{}, errors.New("consensus engine not support")
-}
-
-// GetFinalizedHeader returns the highest finalized block header before the input block.
-func (s *PublicBlockChainAPI) GetFinalizedHeader(ctx context.Context, blockNrOrHash *rpc.BlockNumberOrHash) (*types.Header, error) {
-	bNrOrHash := rpc.BlockNumberOrHashWithNumber(rpc.LatestBlockNumber)
-	if blockNrOrHash != nil {
-		bNrOrHash = *blockNrOrHash
-	}
-
-	// Retrieve the block to act as the gas ceiling
-	header, err := s.b.HeaderByNumberOrHash(ctx, bNrOrHash)
-	if err != nil {
-		return nil, err
-	}
-	if header == nil {
-		return nil, errors.New("block header not found")
-	}
-
-	if posa, ok := s.b.Engine().(consensus.PoSA); ok {
-		return posa.GetFinalizedHeader(s.b.Chain(), header), nil
-	}
-
-	// Not support.
-	return nil, nil
-}
-
 func (s *PublicBlockChainAPI) GetVerifyResult(ctx context.Context, blockNr rpc.BlockNumber, blockHash common.Hash, diffHash common.Hash) *core.VerifyResult {
 	return s.b.Chain().GetVerifyResult(uint64(blockNr), blockHash, diffHash)
 }

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -68,7 +68,7 @@ const (
 )
 
 // UnmarshalJSON parses the given JSON fragment into a BlockNumber. It supports:
-// - "latest", "earliest" or "pending" as string arguments
+// - "safe", "finalized", "latest", "earliest" or "pending" as string arguments
 // - the block number
 // Returned errors:
 // - an invalid block number error when the given argument isn't a known strings
@@ -89,6 +89,12 @@ func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
 	case "pending":
 		*bn = PendingBlockNumber
 		return nil
+	case "finalized":
+		*bn = FinalizedBlockNumber
+		return nil
+	case "safe":
+		*bn = SafeBlockNumber
+		return nil
 	}
 
 	blckNum, err := hexutil.DecodeUint64(input)
@@ -103,7 +109,7 @@ func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalText implements encoding.TextMarshaler. It marshals:
-// - "latest", "earliest" or "pending" as strings
+// - "safe", "finalized", "latest", "earliest" or "pending" as strings
 // - other numbers as hex
 func (bn BlockNumber) MarshalText() ([]byte, error) {
 	switch bn {
@@ -113,6 +119,10 @@ func (bn BlockNumber) MarshalText() ([]byte, error) {
 		return []byte("latest"), nil
 	case PendingBlockNumber:
 		return []byte("pending"), nil
+	case FinalizedBlockNumber:
+		return []byte("finalized"), nil
+	case SafeBlockNumber:
+		return []byte("safe"), nil
 	default:
 		return hexutil.Uint64(bn).MarshalText()
 	}
@@ -157,6 +167,14 @@ func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 		return nil
 	case "pending":
 		bn := PendingBlockNumber
+		bnh.BlockNumber = &bn
+		return nil
+	case "finalized":
+		bn := FinalizedBlockNumber
+		bnh.BlockNumber = &bn
+		return nil
+	case "safe":
+		bn := SafeBlockNumber
 		bnh.BlockNumber = &bn
 		return nil
 	default:


### PR DESCRIPTION
### Description

enhance GetBlockByNumber by supporting 'safe' and 'finalized', following Geth

### Rationale
1. follow up with Geth, to improve user experience, 'finalized' and 'safe' meaning, refer to
    https://www.alchemy.com/overviews/ethereum-commitment-levels
2. transplant code from Geth, 
   and the binding position is CurrentFinalBlock() and CurrentSafeBlock()
3. remove GetFinalizedHeader and GetJustifiedNumberAndHash in ethapi list

### Example
have been tested
curl -X POST "http://127.0.0.1:8545" -H "Content-Type: application/json"  --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["latest", true],"id":1}'
<img width="1263" alt="image" src="https://user-images.githubusercontent.com/122502194/228427181-fa5e0bf3-3df7-4b24-87cd-4aab00831559.png">


curl -X POST "http://127.0.0.1:8545" -H "Content-Type: application/json"  --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["safe", true],"id":1}'
<img width="1255" alt="image" src="https://user-images.githubusercontent.com/122502194/228427260-34ba24a2-caac-4837-a1d4-946014f433d2.png">


curl -X POST "http://127.0.0.1:8545" -H "Content-Type: application/json"  --data '{"jsonrpc":"2.0","method":"eth_getBlockByNumber","params":["finalized", true],"id":1}'
<img width="1254" alt="image" src="https://user-images.githubusercontent.com/122502194/228427316-4081d0a6-0ace-4e06-b146-0cc4fd054b5a.png">


### Changes

Notable changes: 
* add each change in a bullet point here
* ...
