### PR TITLE
witness: generate and verify witness

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -127,7 +127,7 @@ type Trie interface {
 	// with the node that proves the absence of the key.
 	Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWriter) error
 	
-	ProveStorage(key []byte, prefixKey []byte, proofDb ethdb.KeyValueWriter) error
+	ProveStorageWitness(key []byte, prefixKey []byte, proofDb ethdb.KeyValueWriter) error
 
 }
 

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -126,6 +126,9 @@ type Trie interface {
 	// nodes of the longest existing prefix of the key (at least the root), ending
 	// with the node that proves the absence of the key.
 	Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWriter) error
+	
+	ProveStorage(key []byte, prefixKey []byte, proofDb ethdb.KeyValueWriter) error
+
 }
 
 // NewDatabase creates a backing store for state. The returned database is safe for

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -497,13 +497,13 @@ func (s *StateDB) GetProofByHash(addrHash common.Hash) ([][]byte, error) {
 }
 
 // GetStorageWitness returns only the Merkle proof for given storage slot.
-func (s *StateDB) GetStorageWitness(a common.Address, prefixKeyHex []byte, slotKey common.Hash) ([][]byte, error) {
+func (s *StateDB) GetStorageWitness(a common.Address, prefixKeyHex []byte, key common.Hash) ([][]byte, error) {
 	var proof proofList
 	trie := s.StorageTrie(a)
 	if trie == nil {
 		return proof, errors.New("storage trie for requested address does not exist")
 	}
-	err := trie.ProveStorage(crypto.Keccak256(slotKey.Bytes()), prefixKeyHex, &proof)
+	err := trie.ProveStorageWitness(crypto.Keccak256(key.Bytes()), prefixKeyHex, &proof)
 	return proof, err
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -496,14 +496,25 @@ func (s *StateDB) GetProofByHash(addrHash common.Hash) ([][]byte, error) {
 	return proof, err
 }
 
-// GetStorageProof returns the Merkle proof for given storage slot.
-func (s *StateDB) GetStorageProof(a common.Address, prefixKey []byte, key common.Hash) ([][]byte, error) {
+// GetStorageWitness returns only the Merkle proof for given storage slot.
+func (s *StateDB) GetStorageWitness(a common.Address, prefixKeyHex []byte, slotKey common.Hash) ([][]byte, error) {
 	var proof proofList
 	trie := s.StorageTrie(a)
 	if trie == nil {
 		return proof, errors.New("storage trie for requested address does not exist")
 	}
-	err := trie.ProveStorage(crypto.Keccak256(key.Bytes()), prefixKey, &proof)
+	err := trie.ProveStorage(crypto.Keccak256(slotKey.Bytes()), prefixKeyHex, &proof)
+	return proof, err
+}
+
+//  TODO: GetStorageProof returns the combined Merkle proof and Shadow Tree proof for given storage slot.
+func (s *StateDB) GetStorageProof(a common.Address, key common.Hash) ([][]byte, error) {
+	var proof proofList
+	trie := s.StorageTrie(a)
+	if trie == nil {
+		return proof, errors.New("storage trie for requested address does not exist")
+	}
+	err := trie.Prove(crypto.Keccak256(key.Bytes()), 0, &proof)
 	return proof, err
 }
 

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -497,13 +497,13 @@ func (s *StateDB) GetProofByHash(addrHash common.Hash) ([][]byte, error) {
 }
 
 // GetStorageProof returns the Merkle proof for given storage slot.
-func (s *StateDB) GetStorageProof(a common.Address, key common.Hash) ([][]byte, error) {
+func (s *StateDB) GetStorageProof(a common.Address, prefixKey []byte, key common.Hash) ([][]byte, error) {
 	var proof proofList
 	trie := s.StorageTrie(a)
 	if trie == nil {
 		return proof, errors.New("storage trie for requested address does not exist")
 	}
-	err := trie.Prove(crypto.Keccak256(key.Bytes()), 0, &proof)
+	err := trie.ProveStorage(crypto.Keccak256(key.Bytes()), prefixKey, &proof)
 	return proof, err
 }
 

--- a/trie/dummy_trie.go
+++ b/trie/dummy_trie.go
@@ -32,7 +32,7 @@ func (t *EmptyTrie) Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWrit
 	return nil
 }
 
-func (t *EmptyTrie) ProveStorage(key, from []byte, proofDb ethdb.KeyValueWriter) error {
+func (t *EmptyTrie) ProveStorageWitness(key, from []byte, proofDb ethdb.KeyValueWriter) error {
 	return nil
 }
 

--- a/trie/dummy_trie.go
+++ b/trie/dummy_trie.go
@@ -32,6 +32,10 @@ func (t *EmptyTrie) Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWrit
 	return nil
 }
 
+func (t *EmptyTrie) ProveStorage(key, from []byte, proofDb ethdb.KeyValueWriter) error {
+	return nil
+}
+
 // NewSecure creates a dummy trie
 func NewEmptyTrie() *EmptyTrie {
 	return &EmptyTrie{}

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -83,9 +83,8 @@ func (t *SecureTrie) Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWri
 	return t.trie.Prove(key, fromLevel, proofDb)
 }
 
-// ProveStorage constructs a merkle proof for a storage key. The storage key should 
-// already be converted to nibbles. If the prefix key is specified, the proof will 
-// start from the node that contains the prefix key to get the partial proof.
+// ProveStorage constructs a merkle proof for a storage key. If the prefix key is specified, 
+// the proof will start from the node that contains the prefix key to get the partial proof.
 // The result contains all encoded nodes from the starting node to the node that contains
 // the value. The value itself is also included in the last node and can be retrieved by
 // verifying the proof.
@@ -94,6 +93,8 @@ func (t *Trie) ProveStorage(key []byte, prefixKey []byte, proofDb ethdb.KeyValue
 	if len(key) == 0 {
 		return fmt.Errorf("key is empty")
 	}
+
+	key = keybytesToHex(key)
 
 	// traverse down using the prefixKey
 	var nodes []node
@@ -163,15 +164,16 @@ func VerifyProof(rootHash common.Hash, key []byte, proofDb ethdb.KeyValueReader)
 	}
 }
 
-// VerifyStorageProof checks a merkle proof for a storage key. The storage key should 
-// already be converted to nibbles. If the prefix key is specified, it will traverse
-// down to the node that contains the prefix key. From there, proof will be verified.
+// VerifyStorageProof checks a merkle proof for a storage key. If the prefix key is specified, 
+// it will traverse down to the node that contains the prefix key. From there, proof will be verified.
 // VerifyStorageProof returns an error if the proof contains invalid trie nodes.
 func (t *Trie) VerifyStorageProof(key []byte, prefixKey []byte, proofDb ethdb.KeyValueReader) (value []byte, err error) {
 
 	if len(key) == 0 {
 		return nil, fmt.Errorf("empty key provided")
 	}
+	
+	key = keybytesToHex(key)
 
 	tn := t.root
 	startNode, err := t.traverseNodes(tn, prefixKey, nil)

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -130,6 +130,10 @@ func (t *Trie) ProveStorage(key []byte, prefixKey []byte, proofDb ethdb.KeyValue
 	return nil
 }
 
+func (t *SecureTrie) ProveStorage(key []byte, prefixKey []byte, proofDb ethdb.KeyValueWriter) error {
+	return t.trie.ProveStorage(key, prefixKey, proofDb)
+}
+
 // VerifyProof checks merkle proofs. The given proof must contain the value for
 // key in a trie with the given root hash. VerifyProof returns an error if the
 // proof contains invalid trie nodes or the wrong value.

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -83,6 +83,53 @@ func (t *SecureTrie) Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWri
 	return t.trie.Prove(key, fromLevel, proofDb)
 }
 
+// ProveStorage constructs a merkle proof for a storage key. The storage key should 
+// already be converted to nibbles. If the prefix key is specified, the proof will 
+// start from the node that contains the prefix key to get the partial proof.
+// The result contains all encoded nodes from the starting node to the node that contains
+// the value. The value itself is also included in the last node and can be retrieved by
+// verifying the proof.
+func (t *Trie) ProveStorage(key []byte, prefixKey []byte, proofDb ethdb.KeyValueWriter) error {
+
+	if len(key) == 0 {
+		return fmt.Errorf("key is empty")
+	}
+
+	// traverse down using the prefixKey
+	var nodes []node
+	tn := t.root
+	startNode, err := t.traverseNodes(tn, prefixKey, nil) // obtain the node that contains the prefixKey
+	if err != nil {
+		return err
+	}
+
+	key = key[len(prefixKey):] // obtain the suffix key
+
+	// traverse through the suffix key
+	_, err = t.traverseNodes(startNode, key, &nodes)
+	if err != nil{
+		return err
+	}
+
+	hasher := newHasher(false)
+	defer returnHasherToPool(hasher)
+
+	// construct the proof
+	for i, n := range nodes {
+		var hn node
+		n, hn = hasher.proofHash(n)
+		if hash, ok := hn.(hashNode); ok || i == 0 {
+			enc := nodeToBytes(n)
+			if !ok {
+				hash = hasher.hashData(enc)
+			}
+			proofDb.Put(hash, enc)
+		}
+	}
+
+	return nil
+}
+
 // VerifyProof checks merkle proofs. The given proof must contain the value for
 // key in a trie with the given root hash. VerifyProof returns an error if the
 // proof contains invalid trie nodes or the wrong value.

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -27,11 +27,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-type MPTProof struct {
-	prefixKey []byte // prefix key
-	proof [][]byte // list of RLP-encoded nodes
-}
-
 // Prove constructs a merkle proof for key. The result contains all encoded nodes
 // on the path to the value at key. The value itself is also included in the last
 // node and can be retrieved by verifying the proof.

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -27,6 +27,11 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
+type MPTProof struct {
+	prefixKey []byte // prefix key
+	proof [][]byte // list of RLP-encoded nodes
+}
+
 // Prove constructs a merkle proof for key. The result contains all encoded nodes
 // on the path to the value at key. The value itself is also included in the last
 // node and can be retrieved by verifying the proof.

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -901,11 +901,11 @@ func TestStorageProof(t *testing.T){
 		for _, prefixKey := range prefixKeys {
 			proof := memorydb.New()
 			key := kv.k
-			err := trie.ProveStorage(key, prefixKey, proof)
+			err := trie.ProveStorageWitness(key, prefixKey, proof)
 			if err != nil {
 				t.Fatalf("missing key %x while constructing proof", kv.k)
 			}
-			val, err := trie.VerifyStorageProof(key, prefixKey, proof)
+			val, err := trie.VerifyStorageWitness(key, prefixKey, proof)
 			if err != nil {
 				t.Fatalf("failed to verify proof for key %x: prefix %x: %v\nraw proof: %x", key, prefixKey, err, proof)
 			}
@@ -924,7 +924,7 @@ func TestOneElementStorageProof(t *testing.T){
 
 	proof := memorydb.New()
 	key := []byte("k")
-	err := trie.ProveStorage(key, nil, proof)
+	err := trie.ProveStorageWitness(key, nil, proof)
 	if err != nil {
 		t.Fatalf("missing key %x while constructing proof", key)
 	}
@@ -952,7 +952,7 @@ func TestEmptyStorageProof(t *testing.T){
 	proof := memorydb.New()
 	key := []byte("k")
 
-	val, err := trie.VerifyStorageProof(key, nil, proof)
+	val, err := trie.VerifyStorageWitness(key, nil, proof)
 	if val != nil && err != nil{
 		t.Fatalf("expected nil value and error for empty proof")
 	}
@@ -965,7 +965,7 @@ func TestEmptyKeyStorageProof(t *testing.T){
 	updateString(trie, "k", "v")
 
 	proof := memorydb.New()
-	err := trie.ProveStorage([]byte(""), nil, proof)
+	err := trie.ProveStorageWitness([]byte(""), nil, proof)
 	if err == nil {
 		t.Fatalf("expected error for empty key")
 	}
@@ -979,11 +979,11 @@ func TestEmptyPrefixKeyStorageProof(t *testing.T){
 		proof := memorydb.New()
 		key := kv.k
 
-		err := trie.ProveStorage(key, nil, proof)
+		err := trie.ProveStorageWitness(key, nil, proof)
 		if err != nil {
 			t.Fatalf("missing key %x while constructing proof", key)
 		}
-		val, err := trie.VerifyStorageProof(key, nil, proof)
+		val, err := trie.VerifyStorageWitness(key, nil, proof)
 		if err != nil {
 			t.Fatalf("failed to verify proof for key %x: %v\nraw proof: %x", key, err, proof)
 		}
@@ -1003,7 +1003,7 @@ func TestBadStorageProof(t *testing.T){
 		for _, prefixKey := range prefixKeys {
 			proof := memorydb.New()
 			key := []byte(kv.k)
-			err := trie.ProveStorage(key, prefixKey, proof)
+			err := trie.ProveStorageWitness(key, prefixKey, proof)
 			if err != nil {
 				t.Fatalf("missing key %x while constructing proof", key)
 			}
@@ -1024,7 +1024,7 @@ func TestBadStorageProof(t *testing.T){
 			mutateByte(itVal)
 			proof.Put(crypto.Keccak256(itVal), itVal)
 	
-			if val, err := trie.VerifyStorageProof(key, prefixKey, proof); err == nil && val != nil{
+			if val, err := trie.VerifyStorageWitness(key, prefixKey, proof); err == nil && val != nil{
 				t.Fatalf("expected proof to fail for key: %x, prefix: %x", key, prefixKey)
 			}
 		}
@@ -1039,9 +1039,9 @@ func TestBadKeyStorageProof(t *testing.T){
 
 	proof := memorydb.New()
 	key := []byte("x")
-	trie.ProveStorage(key, nil, proof)
+	trie.ProveStorageWitness(key, nil, proof)
 
-	val, err := trie.VerifyStorageProof(key, nil, proof)
+	val, err := trie.VerifyStorageWitness(key, nil, proof)
 	if val != nil && err != nil{
 		t.Fatalf("expected nil value and error for bad key")
 	}
@@ -1058,9 +1058,9 @@ func TestBadPrefixKeyStorageProof(t *testing.T){
 
 	prefixKey := keybytesToHex([]byte("x"))
 
-	trie.ProveStorage(key, prefixKey, proof)
+	trie.ProveStorageWitness(key, prefixKey, proof)
 
-	val, err := trie.VerifyStorageProof(key, prefixKey, proof)
+	val, err := trie.VerifyStorageWitness(key, prefixKey, proof)
 	if val != nil && err != nil{
 		t.Fatalf("expected nil value and error for bad prefix key")
 	}
@@ -1075,12 +1075,12 @@ func TestKeyPrefixKeySame(t *testing.T){
 	proof := memorydb.New()
 	key := []byte("k")	
 
-	trie.ProveStorage(key, key, proof)
+	trie.ProveStorageWitness(key, key, proof)
 	if proof.Len() != 0 {
 		t.Fatalf("expected proof size to be 0 for same key and prefix key")
 	}
 
-	val, err := trie.VerifyStorageProof(key, key, proof)
+	val, err := trie.VerifyStorageWitness(key, key, proof)
 	if val != nil && err != nil{
 		t.Fatalf("expected nil value and error for same key and prefix key")
 	}
@@ -1123,8 +1123,8 @@ func TestUnexpiredStorageProof(t *testing.T) {
 	proof := memorydb.New()
 	key := []byte("degi")
 
-	trie.ProveStorage(key, nil, proof)
-	val, err := trie.VerifyStorageProof(key, nil, proof)
+	trie.ProveStorageWitness(key, nil, proof)
+	val, err := trie.VerifyStorageWitness(key, nil, proof)
 	if err != nil {
 		t.Fatalf("failed to verify proof: %v\nraw proof: %x", err, proof)
 	}

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -900,7 +900,7 @@ func TestStorageProof(t *testing.T){
 		prefixKeys := getPrefixKeys(trie, []byte(kv.k))
 		for _, prefixKey := range prefixKeys {
 			proof := memorydb.New()
-			key := keybytesToHex([]byte(kv.k))
+			key := kv.k
 			err := trie.ProveStorage(key, prefixKey, proof)
 			if err != nil {
 				t.Fatalf("missing key %x while constructing proof", kv.k)
@@ -923,7 +923,7 @@ func TestOneElementStorageProof(t *testing.T){
 	updateString(trie, "k", "v")
 
 	proof := memorydb.New()
-	key := keybytesToHex([]byte("k"))
+	key := []byte("k")
 	err := trie.ProveStorage(key, nil, proof)
 	if err != nil {
 		t.Fatalf("missing key %x while constructing proof", key)
@@ -950,7 +950,7 @@ func TestEmptyStorageProof(t *testing.T){
 	updateString(trie, "k", "v")
 
 	proof := memorydb.New()
-	key := keybytesToHex([]byte("k"))
+	key := []byte("k")
 
 	val, err := trie.VerifyStorageProof(key, nil, proof)
 	if val != nil && err != nil{
@@ -977,7 +977,8 @@ func TestEmptyPrefixKeyStorageProof(t *testing.T){
 	trie, vals := randomTrie(500)
 	for _, kv := range vals {
 		proof := memorydb.New()
-		key := keybytesToHex(kv.k)
+		key := kv.k
+
 		err := trie.ProveStorage(key, nil, proof)
 		if err != nil {
 			t.Fatalf("missing key %x while constructing proof", key)
@@ -1001,7 +1002,7 @@ func TestBadStorageProof(t *testing.T){
 		prefixKeys := getPrefixKeys(trie, []byte(kv.k))
 		for _, prefixKey := range prefixKeys {
 			proof := memorydb.New()
-			key := keybytesToHex([]byte(kv.k))
+			key := []byte(kv.k)
 			err := trie.ProveStorage(key, prefixKey, proof)
 			if err != nil {
 				t.Fatalf("missing key %x while constructing proof", key)
@@ -1037,7 +1038,7 @@ func TestBadKeyStorageProof(t *testing.T){
 	updateString(trie, "k", "v")
 
 	proof := memorydb.New()
-	key := keybytesToHex([]byte("x"))
+	key := []byte("x")
 	trie.ProveStorage(key, nil, proof)
 
 	val, err := trie.VerifyStorageProof(key, nil, proof)
@@ -1053,7 +1054,7 @@ func TestBadPrefixKeyStorageProof(t *testing.T){
 	updateString(trie, "k", "v")
 
 	proof := memorydb.New()
-	key := keybytesToHex([]byte("k"))
+	key := []byte("k")
 
 	prefixKey := keybytesToHex([]byte("x"))
 
@@ -1072,7 +1073,7 @@ func TestKeyPrefixKeySame(t *testing.T){
 	updateString(trie, "k", "v")
 
 	proof := memorydb.New()
-	key := keybytesToHex([]byte("k"))
+	key := []byte("k")	
 
 	trie.ProveStorage(key, key, proof)
 	if proof.Len() != 0 {
@@ -1120,7 +1121,7 @@ func TestUnexpiredStorageProof(t *testing.T) {
 	trie.ExpireByPrefix(prefixKey)
 
 	proof := memorydb.New()
-	key := keybytesToHex([]byte("degi"))
+	key := []byte("degi")
 
 	trie.ProveStorage(key, nil, proof)
 	val, err := trie.VerifyStorageProof(key, nil, proof)


### PR DESCRIPTION
### Description
- decouple code chunks in Prove() to traverseNodes()
- add ProveStorage()
- add VerifyProofStorage()
- modify GetStorageProof()
- add ExpireByPrefix() as a helper function to replace subtree with hash
- add getPrefixByKeys() as a helper function to get all prefix keys along a path
- add function comments
- add unit tests

### Changes

Notable changes: 
* Trie interface implements a new function called ProveStorage()
* GetStorageProof takes in extra parameters for prefix key
* GetStorageProof uses ProveStorage() instead of Prove()
