### PR TITLE
Witness: MPT revive

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -129,6 +129,7 @@ type Trie interface {
 	
 	ProveStorageWitness(key []byte, prefixKey []byte, proofDb ethdb.KeyValueWriter) error
 
+	ReviveTrie(trie.MPTProofCache) error
 }
 
 // NewDatabase creates a backing store for state. The returned database is safe for

--- a/core/state_transition_test.go
+++ b/core/state_transition_test.go
@@ -9,6 +9,17 @@ import (
 	"testing"
 )
 
+func keybytesToHex(str []byte) []byte {
+	l := len(str)*2 + 1
+	var nibbles = make([]byte, l)
+	for i, b := range str {
+		nibbles[i*2] = b / 16
+		nibbles[i*2+1] = b % 16
+	}
+	nibbles[l-1] = 16
+	return nibbles
+}
+
 func makeMerkleProofWitness(addr *common.Address, keyLen, witSize, proofCount, proofLen int) types.ReviveWitness {
 	proofList := make([]types.MPTProof, witSize)
 	for i := range proofList {
@@ -17,7 +28,7 @@ func makeMerkleProofWitness(addr *common.Address, keyLen, witSize, proofCount, p
 			proof[j] = bytes.Repeat([]byte{'p'}, proofLen)
 		}
 		proofList[i] = types.MPTProof{
-			RootKey: bytes.Repeat([]byte{'k'}, keyLen),
+			RootKeyHex: keybytesToHex(bytes.Repeat([]byte{'k'}, keyLen)),
 			Proof:   proof,
 		}
 	}

--- a/core/types/revive_witness.go
+++ b/core/types/revive_witness.go
@@ -24,7 +24,7 @@ const (
 // will verify the whole path later
 // Attention: The proof could revive multi-vals, although it's a single trie path witness
 type MPTProof struct {
-	RootKey []byte   // root key, target the revival path root, max 32bytes
+	RootKeyHex []byte   // prefix key in nibbles format, max 65 bytes. TODO: optimize witness size
 	Proof   [][]byte // list of RLP-encoded nodes
 }
 

--- a/core/types/revive_witness_test.go
+++ b/core/types/revive_witness_test.go
@@ -34,7 +34,7 @@ func makeStorageTrieWitness(addr common.Address, proofCount int, proofLen ...int
 			proof[j] = bytes.Repeat([]byte{'f'}, proofLen[j])
 		}
 		proofList[i] = MPTProof{
-			RootKey: nil,
+			RootKeyHex: nil,
 			Proof:   proof,
 		}
 	}

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -579,7 +579,7 @@ func TestReviveStateTxAndSigner(t *testing.T) {
 	wit := StorageTrieWitness{
 		Address: addr,
 		ProofList: []MPTProof{{
-			RootKey: common.Hex2Bytes("095e7baea6a6c7c4c2"),
+			RootKeyHex: []byte{0x09, 0x5e, 0x7b, 0xae, 0xa6, 0xa6, 0xc7, 0xc4, 0xc2},
 			Proof:   [][]byte{common.Hex2Bytes("6a6c7c4c2dfe7c4c2dac326af552d87baea6a6c7c4c2")},
 		}},
 	}

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -74,6 +74,7 @@ type StateDB interface {
 	AddPreimage(common.Hash, []byte)
 
 	ForEachStorage(common.Address, func(common.Hash, common.Hash) bool) error
+	ReviveTrie(witnessList types.WitnessList) error
 }
 
 // CallContext provides a basic interface for the EVM calling conventions. The EVM

--- a/light/trie.go
+++ b/light/trie.go
@@ -202,6 +202,10 @@ func (db *odrTrie) NoTries() bool {
 	return false
 }
 
+func (t *odrTrie) ReviveTrie(proof trie.MPTProofCache) error {
+	return t.trie.ReviveTrie(proof)
+}
+
 type nodeIterator struct {
 	trie.NodeIterator
 	t   *odrTrie

--- a/trie/dummy_trie.go
+++ b/trie/dummy_trie.go
@@ -103,3 +103,7 @@ func (t *EmptyTrie) NodeIterator(start []byte) NodeIterator {
 func (t *EmptyTrie) TryUpdateAccount(key []byte, account *types.StateAccount) error {
 	return nil
 }
+
+func (t *EmptyTrie) ReviveTrie(proof MPTProofCache) error {
+	return nil
+}

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -227,10 +227,12 @@ func (m *MPTProofCache) VerifyProof() error {
 
 	// cache proof nubs
 	m.cacheNubs = make([]*MPTProofNub, 0, len(m.Proof))
-	prefix := keybytesToHex(m.RootKey)
-	prefix = prefix[:len(prefix)-1]
+	prefix := m.RootKeyHex
 	for i := 0; i < len(m.cacheNodes); i++ {
-		prefix = append(prefix, m.cacheHexPath[i]...)
+		if i - 1 >= 0 {
+			prefix = append(prefix, m.cacheHexPath[i-1]...)
+		}
+		// prefix = append(prefix, m.cacheHexPath[i]...)
 		n1 := m.cacheNodes[i]
 		nub := MPTProofNub{
 			RootHexKey: prefix,
@@ -239,7 +241,7 @@ func (m *MPTProofCache) VerifyProof() error {
 		}
 		if needMergeNextNode(m.cacheNodes, i) {
 			i++
-			prefix = append(prefix, m.cacheHexPath[i]...)
+			prefix = append(prefix, m.cacheHexPath[i-1]...)
 			nub.n2 = m.cacheNodes[i]
 		}
 		m.cacheNubs = append(m.cacheNubs, &nub)
@@ -290,8 +292,8 @@ func matchHashNodeInShortNode(child []byte, n *shortNode) error {
 	}
 
 	switch v := n.Val.(type) {
-	case *hashNode:
-		if !bytes.Equal(child, *v) {
+	case hashNode:
+		if !bytes.Equal(child, v) {
 			return errors.New("proof wrong child in shortNode")
 		}
 	default:

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -900,7 +900,7 @@ func TestAllElementsEmptyValueRangeProof(t *testing.T) {
 func TestStorageProof(t *testing.T) {
 	trie, vals := randomTrie(500)
 	for _, kv := range vals {
-		prefixKeys := getPrefixKeys(trie, []byte(kv.k))
+		prefixKeys := getPrefixKeysHex(trie, []byte(kv.k))
 		for _, prefixKey := range prefixKeys {
 			proof := memorydb.New()
 			key := kv.k
@@ -1002,7 +1002,7 @@ func TestBadStorageProof(t *testing.T) {
 
 	trie, vals := randomTrie(500)
 	for _, kv := range vals {
-		prefixKeys := getPrefixKeys(trie, []byte(kv.k))
+		prefixKeys := getPrefixKeysHex(trie, []byte(kv.k))
 		for _, prefixKey := range prefixKeys {
 			proof := memorydb.New()
 			key := []byte(kv.k)
@@ -1344,7 +1344,7 @@ func TestRangeProofKeysWithSharedPrefix(t *testing.T) {
 	}
 }
 
-func getPrefixKeys(t *Trie, key []byte) [][]byte {
+func getPrefixKeysHex(t *Trie, key []byte) [][]byte {
 	var prefixKeys [][]byte
 	key = keybytesToHex(key)
 	tn := t.root
@@ -1417,7 +1417,7 @@ func makeMPTProofCache(key []byte, proofs []string) MPTProofCache {
 	}
 	return MPTProofCache{
 		MPTProof: types.MPTProof{
-			RootKey: key,
+			RootKeyHex: key,
 			Proof:   proof,
 		},
 	}

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -228,3 +228,7 @@ func (t *SecureTrie) getSecKeyCache() map[string][]byte {
 	}
 	return t.secKeyCache
 }
+
+func (t *SecureTrie) ReviveTrie(proof MPTProofCache) error {
+	return t.trie.ReviveTrie(proof)
+}


### PR DESCRIPTION
### Description

- add StateDB.ReviveTrie() method
- add Trie.ReviveTrie() to revive trie given a Merkle proof
- add UTs

### Changes

Notable changes: 
- add ReviveTrie on StateDB interface
- add ReviveTrie to Trie interface
- decouple revive codes in TransitionDb()
- change RootKey to RootKeyHex in MPTProofNub
- fix minor bugs

#76
