### PR TITLE
EVM: add cache & journal support for state expiry

### DIFF
--- a/core/state/database.go
+++ b/core/state/database.go
@@ -126,7 +126,7 @@ type Trie interface {
 	// nodes of the longest existing prefix of the key (at least the root), ending
 	// with the node that proves the absence of the key.
 	Prove(key []byte, fromLevel uint, proofDb ethdb.KeyValueWriter) error
-	
+
 	ProveStorageWitness(key []byte, prefixKey []byte, proofDb ethdb.KeyValueWriter) error
 
 	ReviveTrie(trie.MPTProofCache) error

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -363,7 +363,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 
 	// revive state before execution
 	if rules.IsElwood {
-		st.state.ReviveTrie(msg.WitnessList())
+		st.state.ReviveStorageTrie(msg.WitnessList())
 	}
 
 	var (

--- a/core/vm/interface.go
+++ b/core/vm/interface.go
@@ -74,7 +74,7 @@ type StateDB interface {
 	AddPreimage(common.Hash, []byte)
 
 	ForEachStorage(common.Address, func(common.Hash, common.Hash) bool) error
-	ReviveTrie(witnessList types.WitnessList) error
+	ReviveStorageTrie(witnessList types.WitnessList) error
 }
 
 // CallContext provides a basic interface for the EVM calling conventions. The EVM

--- a/trie/dummy_trie.go
+++ b/trie/dummy_trie.go
@@ -18,7 +18,6 @@ package trie
 
 import (
 	"fmt"
-
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -180,8 +180,8 @@ type MPTProofCache struct {
 // VerifyProof verify proof in MPT witness
 // 1. calculate hash
 // 2. decode trie node
-// 3. verify partial merkle proof of the witness
-// 4. split to partial witness
+// 3. verify partial merkle proof of the witness, TODO match algo will check inner mem node scene, until meet hash node or value node or nil?
+// 4. split to partial witness, TODO check if satisfy partial witness rules?
 // TODO later revive state could revive KV from fullNode[0-15] or fullNode[16] shortNode.Val, return KVs for cache & snap
 // another easy method is that revive direct to Trie/Trie cache, query later and set to KV cache
 func (m *MPTProofCache) VerifyProof() error {
@@ -229,7 +229,7 @@ func (m *MPTProofCache) VerifyProof() error {
 	m.cacheNubs = make([]*MPTProofNub, 0, len(m.Proof))
 	prefix := m.RootKeyHex
 	for i := 0; i < len(m.cacheNodes); i++ {
-		if i - 1 >= 0 {
+		if i-1 >= 0 {
 			prefix = append(prefix, m.cacheHexPath[i-1]...)
 		}
 		// prefix = append(prefix, m.cacheHexPath[i]...)
@@ -244,6 +244,7 @@ func (m *MPTProofCache) VerifyProof() error {
 			prefix = append(prefix, m.cacheHexPath[i-1]...)
 			nub.n2 = m.cacheNodes[i]
 		}
+		// TODO check short node must with child in same nub
 		m.cacheNubs = append(m.cacheNubs, &nub)
 	}
 

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -1386,6 +1386,13 @@ func getPrefixKeysHex(t *Trie, key []byte) [][]byte {
 	return prefixKeys
 }
 
+// TODO add more UTs
+// 1. whole trie expired without root node
+// 2. whole trie expired with root node
+// 3. witness with one short node, val is full node
+// 3. witness with one short node, val is value node
+// 3. witness with one short node, val is recursive full node + short node + value node
+// 4. witness with one full node with val node, children is short node and recursive full node + short node + value node
 func TestMPTProofCache_VerifyProof_normalCase(t *testing.T) {
 	cache := makeMPTProofCache(nil, []string{
 		"0xf90211a03697534056039e03300557bd69fe16e18ce4a6ccd5522db4dfa97dfe1fad3d3aa0b1bf1f230b98b9034738d599177ae817c08143b9395a47f300636b0dd2fb3c5ea0aa04a4966751d4c50063fe13a96a6c7924f665819733f556849b5eb9fa1d6839a0e162e080d1c12c59dc984fb2246d8ad61209264bee40d3fdd07c4ea4ff411b6aa0e5c3f2dde71bf303423f34674748567dcdf8379129653b8213f698468738d492a068a3e3059b6e7115a055a7874f81c5a1e84ddc1967527973f8c78cd86a1c9f8fa0d734bd63b7be8e8471091b792f5bbcbc7b0ce582f6d985b7a15a3c0155242c56a00143c06f57a65c8485dbae750aa51df5dff1bf7bdf28060129a20de9e51364eda07b416f79b3f4e39d0159efff351009d44002d9e83530fb5a5778eb55f5f4432ca036706b52196fa0b73feb2e7ff8f1379c7176d427dd44ad63c7b65e66693904a1a0fd6c8b815e2769ce379a20eaccdba1f145fb11f77c280553f15ee4f1ee135375a02f5233009f082177e5ed2bfa6e180bf1a7310e6bc3c079cb85a4ac6fee4ae379a03f07f1bb33fa26ebd772fa874914dc7a08581095e5159fdcf9221be6cbeb6648a097557eec1ac08c3bfe45ce8e34cd329164a33928ac83fef1009656536ef6907fa028196bfb31aa7f14a0a8000b00b0aa5d09450c32d537e45eebee70b14313ff1ca0126ce265ca7bbb0e0b01f068d1edef1544cbeb2f048c99829713c18d7abc049a80",
@@ -1406,7 +1413,9 @@ func TestMPTProofCache_VerifyProof_normalCase(t *testing.T) {
 	h.sha.Reset()
 	h.sha.Write(key)
 	h.sha.Read(hash)
-	assert.Equal(t, hash, hexToKeybytes(cache.cacheNubs[6].RootHexKey))
+	ln := cache.cacheNubs[6].n1.(*shortNode)
+	hexKey := append(cache.cacheNubs[6].RootHexKey, ln.Key...)
+	assert.Equal(t, hash, hexToKeybytes(hexKey))
 }
 
 func makeMPTProofCache(key []byte, proofs []string) MPTProofCache {
@@ -1418,7 +1427,7 @@ func makeMPTProofCache(key []byte, proofs []string) MPTProofCache {
 	return MPTProofCache{
 		MPTProof: types.MPTProof{
 			RootKeyHex: key,
-			Proof:   proof,
+			Proof:      proof,
 		},
 	}
 }

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -506,7 +506,7 @@ func (t *Trie) ExpireByPrefix(prefixKeyHex []byte) error {
 		t.root = hn
 	}
 	if err != nil {
-		return err 
+		return err
 	}
 	return nil
 }
@@ -666,10 +666,10 @@ func (t *Trie) Size() int {
 
 // ReviveTrie revives the trie from the proof cache
 func (t *Trie) ReviveTrie(proof MPTProofCache) error {
-	
+
 	var parent node
 	var childIndex int // If parent is a fullNode, childIndex is the index of the child node
-	
+
 	cacheHashIndex := 0 // Keep track of the index of the cachedHash
 	nubs := proof.cacheNubs
 
@@ -717,6 +717,7 @@ loopNubs:
 				// Attach n1 to the trie
 				switch n := parent.(type) {
 				case *shortNode:
+					// TODO should copy node and parent point to new node
 					n.Val = nub.n1
 					parent = n.Val
 				case *fullNode:
@@ -727,13 +728,13 @@ loopNubs:
 
 				// Attach n2 to the trie if exists
 				if nub.n2 != nil {
-				switch n := parent.(type) {
-				case *shortNode:
-					n.Val = nub.n2
-				default:
-					return fmt.Errorf("n2 should only be attached to a shortNode")
-				}
-				// TODO (asyukii): build shadow node if n2 is a fullNode
+					switch n := parent.(type) {
+					case *shortNode:
+						n.Val = nub.n2
+					default:
+						return fmt.Errorf("n2 should only be attached to a shortNode")
+					}
+					// TODO (asyukii): build shadow node if n2 is a fullNode
 				}
 			}
 		}
@@ -749,4 +750,3 @@ loopNubs:
 
 	return nil
 }
-

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -39,8 +39,8 @@ import (
 	"github.com/ethereum/go-ethereum/ethdb/leveldb"
 	"github.com/ethereum/go-ethereum/ethdb/memorydb"
 	"github.com/ethereum/go-ethereum/rlp"
-	"golang.org/x/crypto/sha3"
 	"github.com/stretchr/testify/assert"
+	"golang.org/x/crypto/sha3"
 )
 
 func init() {
@@ -475,10 +475,9 @@ func TestRandom(t *testing.T) {
 	}
 }
 
-
-// TestExpireByPrefix tests that the trie is not corrupted after 
+// TestExpireByPrefix tests that the trie is not corrupted after
 // expiring a key by prefix.
-func TestExpireByPrefix(t *testing.T){
+func TestExpireByPrefix(t *testing.T) {
 	data := map[string]string{
 		"abcd": "A",
 		"abce": "B",
@@ -494,7 +493,7 @@ func TestExpireByPrefix(t *testing.T){
 	rootHash := trie.Hash()
 
 	for k := range data {
-		prefixKeys :=  getPrefixKeysHex(trie, []byte(k))
+		prefixKeys := getPrefixKeysHex(trie, []byte(k))
 		for _, prefixKey := range prefixKeys {
 			trie.ExpireByPrefix(prefixKey)
 			currHash := trie.Hash()
@@ -507,7 +506,7 @@ func TestExpireByPrefix(t *testing.T){
 	}
 }
 
-func createCustomTrie(data map[string]string) *Trie{
+func createCustomTrie(data map[string]string) *Trie {
 	trie := new(Trie)
 	for k, v := range data {
 		trie.Update([]byte(k), []byte(v))
@@ -531,13 +530,13 @@ func makeRawMPTProofCache(rootKeyHex []byte, proof [][]byte) MPTProofCache {
 	return MPTProofCache{
 		MPTProof: types.MPTProof{
 			RootKeyHex: rootKeyHex,
-			Proof:   proof,
+			Proof:      proof,
 		},
 	}
 }
 
 // TestReviveTrie tests that a trie can be revived from a proof
-func TestReviveTrie(t *testing.T){
+func TestReviveTrie(t *testing.T) {
 
 	trie, vals := nonRandomTrie(500)
 
@@ -578,10 +577,10 @@ func TestReviveTrie(t *testing.T){
 			// Reset trie
 			trie, _ = nonRandomTrie(500)
 		}
-	}		
+	}
 }
 
-// TODO (asyukii): TestReviveAtRoot tests that a key can be revived at root when 
+// TODO (asyukii): TestReviveAtRoot tests that a key can be revived at root when
 // the whole trie is expired. This test will fail because the parent node in
 // ReviveTrie is nil, set to RootNode when available
 // func TestReviveAtRoot(t *testing.T) {
@@ -613,7 +612,6 @@ func TestReviveTrie(t *testing.T){
 // 		err = trie.ReviveTrie(proofCache)
 // 		assert.NoError(t, err)
 
-
 // 		// Verify value exists after revive
 // 		v := trie.Get(key)
 // 		assert.Equal(t, val, v)
@@ -630,7 +628,7 @@ func TestReviveTrie(t *testing.T){
 
 // TestReviveBadProof tests that a trie cannot be revived from a bad proof
 func TestReviveBadProof(t *testing.T) {
-	
+
 	dataA := map[string]string{
 		"abcd": "A", "abce": "B", "abde": "C", "abdf": "D",
 		"defg": "E", "defh": "F", "degh": "G", "degi": "H",
@@ -698,7 +696,7 @@ func TestReviveOneElement(t *testing.T) {
 	assert.Equal(t, val, v)
 }
 
-// TestReviveBadProofAfterUpdate tests that after reviving a path and 
+// TestReviveBadProofAfterUpdate tests that after reviving a path and
 // then update the value, old proof should be invalid
 func TestReviveBadProofAfterUpdate(t *testing.T) {
 	trie, vals := nonRandomTrie(500)
@@ -753,7 +751,7 @@ func TestPartialReviveFullProof(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Expire trie
-	err = trie.ExpireByPrefix([]byte{6,1})
+	err = trie.ExpireByPrefix([]byte{6, 1})
 	assert.NoError(t, err)
 
 	// Construct MPTProofCache
@@ -777,16 +775,16 @@ func TestPartialReviveFullProof(t *testing.T) {
 // full node can be revived properly
 func TestReviveValueAtFullNode(t *testing.T) {
 	hexKeys := [][]byte{
-		{6,1,6,2,6,3,6,4,16},
-		{6,1,6,2,6,3,6,5,16},
-		{6,1,6,2,6,4,6,5,16},
-		{6,1,6,2,6,4,6,6,16},
-		{6,4,6,5,6,6,6,7,16},
-		{6,4,6,5,6,6,6,8,16},
-		{6,4,6,5,6,7,6,8,16},
-		{6,4,6,5,6,7,6,9,16},
-		{6,1,6,2,6,3,6,4,16},
-		{6,1,6,2,16}, // This is the key that has a value at a full node
+		{6, 1, 6, 2, 6, 3, 6, 4, 16},
+		{6, 1, 6, 2, 6, 3, 6, 5, 16},
+		{6, 1, 6, 2, 6, 4, 6, 5, 16},
+		{6, 1, 6, 2, 6, 4, 6, 6, 16},
+		{6, 4, 6, 5, 6, 6, 6, 7, 16},
+		{6, 4, 6, 5, 6, 6, 6, 8, 16},
+		{6, 4, 6, 5, 6, 7, 6, 8, 16},
+		{6, 4, 6, 5, 6, 7, 6, 9, 16},
+		{6, 1, 6, 2, 6, 3, 6, 4, 16},
+		{6, 1, 6, 2, 16}, // This is the key that has a value at a full node
 	}
 
 	byteKeys := make([][]byte, len(hexKeys))


### PR DESCRIPTION
### Description

add cache & journal support for state expiry, leave some TODOs about shadow nodes.

### Changes

Notable changes: 
* state/journal: add revive journal;
* state/stateDB: opt revive state;
* state/state_object: record AccessedState, opt pending revive trie;
* state/journal: add access state journal;