### PR TITLE
feat(shadownode): support shadow node history store & query

### DIFF
--- a/core/rawdb/accessors_shadow_node.go
+++ b/core/rawdb/accessors_shadow_node.go
@@ -1,0 +1,91 @@
+package rawdb
+
+import (
+	"encoding/binary"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+func DeleteShadowNodeSnapshotJournal(db ethdb.KeyValueWriter) {
+	if err := db.Delete(shadowNodeSnapshotJournalKey); err != nil {
+		log.Crit("Failed to remove snapshot journal", "err", err)
+	}
+}
+
+func ReadShadowNodeSnapshotJournal(db ethdb.KeyValueReader) []byte {
+	data, _ := db.Get(shadowNodeSnapshotJournalKey)
+	return data
+}
+
+func WriteShadowNodeSnapshotJournal(db ethdb.KeyValueWriter, journal []byte) {
+	if err := db.Put(shadowNodeSnapshotJournalKey, journal); err != nil {
+		log.Crit("Failed to store snapshot journal", "err", err)
+	}
+}
+
+func ReadShadowNodePlainStateMeta(db ethdb.KeyValueReader) []byte {
+	data, _ := db.Get(shadowNodePlainStateMeta)
+	return data
+}
+
+func WriteShadowNodePlainStateMeta(db ethdb.KeyValueWriter, val []byte) error {
+	return db.Put(shadowNodePlainStateMeta, val)
+}
+
+func ReadShadowNodeHistory(db ethdb.KeyValueReader, addr common.Hash, path string, number uint64) []byte {
+	val, _ := db.Get(shadowNodeHistoryKey(addr, path, number))
+	return val
+}
+
+func WriteShadowNodeHistory(db ethdb.KeyValueWriter, addr common.Hash, path string, number uint64, val []byte) error {
+	return db.Put(shadowNodeHistoryKey(addr, path, number), val)
+}
+
+func ReadShadowNodeChangeSet(db ethdb.KeyValueReader, addr common.Hash, number uint64) []byte {
+	val, _ := db.Get(shadowNodeChangeSetKey(addr, number))
+	return val
+}
+
+func WriteShadowNodeChangeSet(db ethdb.KeyValueWriter, addr common.Hash, number uint64, val []byte) error {
+	return db.Put(shadowNodeChangeSetKey(addr, number), val)
+}
+
+func ReadShadowNodePlainState(db ethdb.KeyValueReader, addr common.Hash, path string) []byte {
+	val, _ := db.Get(shadowNodePlainStateKey(addr, path))
+	return val
+}
+
+func WriteShadowNodePlainState(db ethdb.KeyValueWriter, addr common.Hash, path string, val []byte) error {
+	return db.Put(shadowNodePlainStateKey(addr, path), val)
+}
+
+func DeleteShadowNodePlainState(db ethdb.KeyValueWriter, addr common.Hash, path string) error {
+	return db.Delete(shadowNodePlainStateKey(addr, path))
+}
+
+func shadowNodeChangeSetKey(addr common.Hash, number uint64) []byte {
+	key := make([]byte, len(ShadowNodeChangeSetPrefix)+8+len(addr))
+	copy(key[:], ShadowNodeHistoryPrefix)
+	binary.BigEndian.PutUint64(key[len(ShadowNodeHistoryPrefix):], number)
+	copy(key[len(ShadowNodeHistoryPrefix)+8:], addr.Bytes())
+	return key
+}
+
+func shadowNodeHistoryKey(addr common.Hash, path string, number uint64) []byte {
+	key := make([]byte, len(ShadowNodeHistoryPrefix)+len(addr)+len(path)+8)
+	copy(key[:], ShadowNodeHistoryPrefix)
+	copy(key[len(ShadowNodeHistoryPrefix):], addr.Bytes())
+	copy(key[len(ShadowNodeHistoryPrefix)+len(addr):], path)
+	binary.BigEndian.PutUint64(key[len(key)-8:], number)
+	return key
+}
+
+func shadowNodePlainStateKey(addr common.Hash, path string) []byte {
+	key := make([]byte, len(ShadowNodePlainStatePrefix)+len(addr)+len(path))
+	copy(key[:], ShadowNodeHistoryPrefix)
+	copy(key[len(ShadowNodeHistoryPrefix):], addr.Bytes())
+	copy(key[len(ShadowNodeHistoryPrefix)+len(addr):], path)
+	return key
+}

--- a/core/rawdb/accessors_snapshot.go
+++ b/core/rawdb/accessors_snapshot.go
@@ -141,23 +141,6 @@ func DeleteSnapshotJournal(db ethdb.KeyValueWriter) {
 	}
 }
 
-func ReadShadowNodeSnapshotJournal(db ethdb.KeyValueReader) []byte {
-	data, _ := db.Get(shadowNodeSnapshotJournalKey)
-	return data
-}
-
-func WriteShadowNodeSnapshotJournal(db ethdb.KeyValueWriter, journal []byte) {
-	if err := db.Put(shadowNodeSnapshotJournalKey, journal); err != nil {
-		log.Crit("Failed to store snapshot journal", "err", err)
-	}
-}
-
-func DeleteShadowNodeSnapshotJournal(db ethdb.KeyValueWriter) {
-	if err := db.Delete(shadowNodeSnapshotJournalKey); err != nil {
-		log.Crit("Failed to remove snapshot journal", "err", err)
-	}
-}
-
 // ReadSnapshotGenerator retrieves the serialized snapshot generator saved at
 // the last shutdown.
 func ReadSnapshotGenerator(db ethdb.KeyValueReader) []byte {

--- a/core/rawdb/schema.go
+++ b/core/rawdb/schema.go
@@ -96,6 +96,9 @@ var (
 	// transitionStatusKey tracks the eth2 transition status.
 	transitionStatusKey = []byte("eth2-transition")
 
+	// shadowNodePlainStateMeta save disk layer meta data
+	shadowNodePlainStateMeta = []byte("shadowNodePlainStateMeta")
+
 	// Data item prefixes (use single byte to avoid mixing data types, avoid `i`, used for indexes).
 	headerPrefix       = []byte("h") // headerPrefix + num (uint64 big endian) + hash -> header
 	headerTDSuffix     = []byte("t") // headerPrefix + num (uint64 big endian) + hash + headerTDSuffix -> td
@@ -110,6 +113,10 @@ var (
 	SnapshotAccountPrefix = []byte("a") // SnapshotAccountPrefix + account hash -> account trie value
 	SnapshotStoragePrefix = []byte("o") // SnapshotStoragePrefix + account hash + storage hash -> storage trie value
 	CodePrefix            = []byte("c") // CodePrefix + code hash -> account code
+
+	ShadowNodeHistoryPrefix    = []byte("sh") // ShadowNodeHistoryPrefix + addr hash + path + blockNr -> bitmap, default blockNr = math.MaxUint64
+	ShadowNodeChangeSetPrefix  = []byte("sc") // ShadowNodeChangeSetPrefix + addr hash + blockNr -> changeSet/prev val
+	ShadowNodePlainStatePrefix = []byte("sp") // ShadowNodePlainStatePrefix + addr hash + path -> val
 
 	// difflayer database
 	diffLayerPrefix = []byte("d") // diffLayerPrefix + hash  -> diffLayer

--- a/go.mod
+++ b/go.mod
@@ -77,12 +77,14 @@ require (
 require (
 	github.com/Azure/azure-pipeline-go v0.2.2 // indirect
 	github.com/Azure/go-autorest/autorest/adal v0.8.0 // indirect
+	github.com/RoaringBitmap/roaring v1.2.3 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.0.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.0.2 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.1.1 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sts v1.1.1 // indirect
 	github.com/aws/smithy-go v1.1.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bits-and-blooms/bitset v1.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
 	github.com/dlclark/regexp2 v1.4.1-0.20201116162257-a2a8dda75c91 // indirect
@@ -101,6 +103,7 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/mitchellh/pointerstructure v1.2.0 // indirect
+	github.com/mschoch/smat v0.2.0 // indirect
 	github.com/naoina/go-stringutil v0.1.0 // indirect
 	github.com/opentracing/opentracing-go v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
+github.com/RoaringBitmap/roaring v1.2.3 h1:yqreLINqIrX22ErkKI0vY47/ivtJr6n+kMhVOVmhWBY=
+github.com/RoaringBitmap/roaring v1.2.3/go.mod h1:plvDsJQpxOC5bw8LRteu/MLWHsHez/3y6cubLI4/1yE=
 github.com/VictoriaMetrics/fastcache v1.6.0 h1:C/3Oi3EiBCqufydp1neRZkqcwmEiuRT9c3fqvvgKm5o=
 github.com/VictoriaMetrics/fastcache v1.6.0/go.mod h1:0qHz5QP0GMX4pfmMA/zt5RgfNuXJrTP0zS7DqpHGGTw=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
@@ -95,6 +97,8 @@ github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bits-and-blooms/bitset v1.2.0 h1:Kn4yilvwNtMACtf1eYDlG8H77R07mZSPbMjLyS07ChA=
+github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/bmizerany/pat v0.0.0-20170815010413-6226ea591a40/go.mod h1:8rLXio+WjiTceGBHIoTvn60HIbs7Hm7bcHjyrSqYB9c=
 github.com/bnb-chain/ics23 v0.1.0 h1:DvjGOts2FBfbxB48384CYD1LbcrfjThFz8kowY/7KxU=
 github.com/bnb-chain/ics23 v0.1.0/go.mod h1:cU6lTGolbbLFsGCgceNB2AzplH1xecLp6+KXvxM32nI=
@@ -402,6 +406,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lN
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/mschoch/smat v0.0.0-20160514031455-90eadee771ae/go.mod h1:qAyveg+e4CE+eKJXWVjKXM4ck2QobLqTDytGJbLLhJg=
+github.com/mschoch/smat v0.2.0 h1:8imxQsjDm8yFEAVBe7azKmKSgzSkZXDuKkSq9374khM=
+github.com/mschoch/smat v0.2.0/go.mod h1:kc9mz7DoBKqDyiRL7VZN8KvXQMWeTaVnttLRXOlotKw=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/naoina/go-stringutil v0.1.0 h1:rCUeRUHjBjGTSHl0VC00jUPLz8/F9dDzYI70Hzifhks=

--- a/trie/shadow_node_history.go
+++ b/trie/shadow_node_history.go
@@ -1,0 +1,86 @@
+package trie
+
+import (
+	"bytes"
+	"errors"
+
+	"github.com/RoaringBitmap/roaring/roaring64"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/ethdb"
+	"github.com/ethereum/go-ethereum/rlp"
+)
+
+func FindHistory(db ethdb.KeyValueStore, number uint64, addr common.Hash, path string) ([]byte, error) {
+	val, found, err := findHistory(db, number, addr, path)
+	if err != nil {
+		return nil, err
+	}
+
+	if found {
+		return val, nil
+	}
+
+	// query from plain state
+	return rawdb.ReadShadowNodePlainState(db, addr, path), nil
+}
+
+type nodeChgRecord struct {
+	Path string
+	Prev []byte
+}
+
+func findHistory(db ethdb.KeyValueStore, number uint64, addr common.Hash, path string) ([]byte, bool, error) {
+	// TODO(0xbundler): split shards according bitmap size later, less than 1mb
+	hbytes := rawdb.ReadShadowNodeHistory(db, addr, path, math.MaxUint64)
+	if len(hbytes) == 0 {
+		return nil, false, nil
+	}
+
+	index := roaring64.New()
+	if _, err := index.ReadFrom(bytes.NewReader(hbytes)); err != nil {
+		return nil, false, err
+	}
+	found, ok := SeekInBitmap64(index, number)
+	if !ok {
+		return nil, false, nil
+	}
+
+	// TODO(0xbundler): using mdbx's DupSort?
+	changeSet := rawdb.ReadShadowNodeChangeSet(db, addr, found)
+	if len(changeSet) == 0 {
+		return nil, false, errors.New("cannot find target changeSet")
+	}
+	var ns []nodeChgRecord
+	if err := rlp.DecodeBytes(changeSet, &ns); err != nil {
+		return nil, false, err
+	}
+	nodeSetMap := make(map[string][]byte)
+	for _, n := range ns {
+		nodeSetMap[n.Path] = n.Prev
+	}
+
+	val, exist := nodeSetMap[path]
+	if !exist {
+		return nil, false, errors.New("cannot find path's change val")
+	}
+
+	return val, true, nil
+}
+
+// SeekInBitmap - returns value in bitmap which is >= n
+func SeekInBitmap64(m *roaring64.Bitmap, n uint64) (found uint64, ok bool) {
+	if m.IsEmpty() {
+		return 0, false
+	}
+	if n == 0 {
+		return m.Minimum(), true
+	}
+	searchRank := m.Rank(n - 1)
+	if searchRank >= m.GetCardinality() {
+		return 0, false
+	}
+	found, _ = m.Select(searchRank)
+	return found, true
+}

--- a/trie/shadow_node_history_test.go
+++ b/trie/shadow_node_history_test.go
@@ -1,0 +1,55 @@
+package trie
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/ethdb/memorydb"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestShadowNodeHistory_Diff2Disk(t *testing.T) {
+	diskdb := memorydb.New()
+	diskLayer, err := loadDiskLayer(diskdb)
+	assert.NoError(t, err)
+	diff := newShadowNodeDiffLayer(common.Big1, blockRoot1, nil, makeNodeSet(contract1, []string{"hello", "world"}))
+	_, err = diskLayer.PushDiff(diff)
+	assert.NoError(t, err)
+
+	// find history
+	val, err := FindHistory(diskdb, common.Big2.Uint64(), contract1, "hello")
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("world"), val)
+	val, err = FindHistory(diskdb, common.Big1.Uint64(), contract1, "hello")
+	assert.NoError(t, err)
+	assert.Equal(t, []byte{}, val)
+
+	// reload disk layer
+	diskLayer, err = loadDiskLayer(diskdb)
+	assert.NoError(t, err)
+	val, err = diskLayer.ShadowNode(contract1, "hello")
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("world"), val)
+}
+
+func TestShadowNodeHistory_case2(t *testing.T) {
+	diskdb := memorydb.New()
+	diskLayer, err := loadDiskLayer(diskdb)
+	assert.NoError(t, err)
+
+	diff := newShadowNodeDiffLayer(common.Big1, blockRoot1, nil, makeNodeSet(contract1, []string{"hello", "world"}))
+	diskLayer, err = diskLayer.PushDiff(diff)
+	assert.NoError(t, err)
+
+	diff = newShadowNodeDiffLayer(common.Big2, blockRoot2, nil, makeNodeSet(contract1, []string{"hello", "world1"}))
+	diskLayer, err = diskLayer.PushDiff(diff)
+	assert.NoError(t, err)
+
+	val, err := FindHistory(diskdb, common.Big2.Uint64(), contract1, "hello")
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("world"), val)
+
+	val, err = FindHistory(diskdb, common.Big3.Uint64(), contract1, "hello")
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("world1"), val)
+}

--- a/trie/shadow_node_test.go
+++ b/trie/shadow_node_test.go
@@ -1,7 +1,11 @@
 package trie
 
 import (
+	"math/big"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/core/rawdb"
+	"github.com/ethereum/go-ethereum/rlp"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb/memorydb"
@@ -12,39 +16,79 @@ func TestShadowNodeRW_CRUD(t *testing.T) {
 	diskdb := memorydb.New()
 	tree, err := NewShadowNodeSnapTree(diskdb)
 	assert.NoError(t, err)
-	storageRW, err := NewShadowNodeStorageRW(tree, blockRoot1)
+	storageDB, err := NewShadowNodeDatabase(tree, common.Big1, blockRoot1)
 	assert.NoError(t, err)
 
-	err = storageRW.Put(contract1, "hello", []byte("world"))
+	err = storageDB.Put(contract1, "hello", []byte("world"))
 	assert.NoError(t, err)
-	err = storageRW.Put(contract1, "hello", []byte("world"))
+	err = storageDB.Put(contract1, "hello", []byte("world"))
 	assert.NoError(t, err)
-	val, err := storageRW.Get(contract1, "hello")
+	val, err := storageDB.Get(contract1, "hello")
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("world"), val)
-	err = storageRW.Delete(contract1, "hello")
+	err = storageDB.Delete(contract1, "hello")
 	assert.NoError(t, err)
-	val, err = storageRW.Get(contract1, "hello")
+	val, err = storageDB.Get(contract1, "hello")
 	assert.NoError(t, err)
 	assert.Equal(t, []byte(nil), val)
+}
+
+func TestShadowNodeRO_Get(t *testing.T) {
+	diskdb := memorydb.New()
+	makeDiskLayer(diskdb, common.Big2, blockRoot2, contract1, []string{"k1", "v1"})
+
+	tree, err := NewShadowNodeSnapTree(diskdb)
+	assert.NoError(t, err)
+	storageRO, err := NewShadowNodeDatabase(tree, common.Big1, blockRoot1)
+	assert.NoError(t, err)
+
+	err = storageRO.Put(contract1, "hello", []byte("world"))
+	assert.Error(t, err)
+	err = storageRO.Delete(contract1, "hello")
+	assert.Error(t, err)
+	err = storageRO.Commit(common.Big2, blockRoot2)
+	assert.Error(t, err)
+
+	val, err := storageRO.Get(contract1, "hello")
+	assert.NoError(t, err)
+	assert.Equal(t, []byte(nil), val)
+	val, err = storageRO.Get(contract1, "k1")
+	assert.NoError(t, err)
+	assert.Equal(t, []byte("v1"), val)
+}
+
+func makeDiskLayer(diskdb *memorydb.Database, number *big.Int, root common.Hash, addr common.Hash, kv []string) {
+	if len(kv)%2 != 0 {
+		panic("wrong kv")
+	}
+	meta := shadowNodePlainMeta{
+		BlockNumber: number,
+		BlockRoot:   root,
+	}
+	enc, _ := rlp.EncodeToBytes(&meta)
+	rawdb.WriteShadowNodePlainStateMeta(diskdb, enc)
+
+	for i := 0; i < len(kv); i += 2 {
+		rawdb.WriteShadowNodePlainState(diskdb, addr, kv[i], []byte(kv[i+1]))
+	}
 }
 
 func TestShadowNodeRW_Commit(t *testing.T) {
 	diskdb := memorydb.New()
 	tree, err := NewShadowNodeSnapTree(diskdb)
 	assert.NoError(t, err)
-	storageRW, err := NewShadowNodeStorageRW(tree, blockRoot1)
+	storageDB, err := NewShadowNodeDatabase(tree, common.Big1, blockRoot1)
 	assert.NoError(t, err)
 
-	err = storageRW.Put(contract1, "hello", []byte("world"))
+	err = storageDB.Put(contract1, "hello", []byte("world"))
 	assert.NoError(t, err)
 
-	err = storageRW.Commit(common.Big1, blockRoot1)
+	err = storageDB.Commit(common.Big1, blockRoot1)
 	assert.NoError(t, err)
 
-	storageRW, err = NewShadowNodeStorageRW(tree, blockRoot1)
+	storageDB, err = NewShadowNodeDatabase(tree, common.Big1, blockRoot1)
 	assert.NoError(t, err)
-	val, err := storageRW.Get(contract1, "hello")
+	val, err := storageDB.Get(contract1, "hello")
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("world"), val)
 }
@@ -53,11 +97,11 @@ func TestNewShadowNodeStorage4Trie(t *testing.T) {
 	diskdb := memorydb.New()
 	tree, err := NewShadowNodeSnapTree(diskdb)
 	assert.NoError(t, err)
-	storageRW, err := NewShadowNodeStorageRW(tree, blockRoot1)
+	storageDB, err := NewShadowNodeDatabase(tree, common.Big1, blockRoot1)
 	assert.NoError(t, err)
 
-	s1 := storageRW.OpenStorage(contract1)
-	s2 := storageRW.OpenStorage(contract2)
+	s1 := storageDB.OpenStorage(contract1)
+	s2 := storageDB.OpenStorage(contract2)
 	val, err := s1.Get("hello")
 	assert.NoError(t, err)
 	assert.Equal(t, []byte(nil), val)
@@ -76,6 +120,6 @@ func TestNewShadowNodeStorage4Trie(t *testing.T) {
 	val, _ = s2.Get("h2")
 	assert.Equal(t, []byte("w2"), val)
 
-	err = storageRW.Commit(common.Big1, blockRoot2)
+	err = storageDB.Commit(common.Big1, blockRoot2)
 	assert.NoError(t, err)
 }

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -941,7 +941,7 @@ func (t *Trie) resolveShadowNode(epoch types.StateEpoch, cur node, prefix []byte
 		return nil
 	}
 
-	if t.currentEpoch > 0 && t.sndb == nil {
+	if t.sndb == nil {
 		return errors.New("cannot resolve shadow node")
 	}
 

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -837,10 +837,10 @@ func TestTrie_ShadowNodeRW(t *testing.T) {
 	database := NewDatabase(diskdb)
 	tree, err := NewShadowNodeSnapTree(diskdb)
 	assert.NoError(t, err)
-	storageRW, err := NewShadowNodeStorageRW(tree, blockRoot0)
+	storageDB, err := NewShadowNodeDatabase(tree, common.Big0, blockRoot0)
 	assert.NoError(t, err)
 
-	tr, err := NewStorageSecure(types.StateEpoch(1), emptyRoot, database, storageRW.OpenStorage(contract1))
+	tr, err := NewStorageSecure(types.StateEpoch(1), emptyRoot, database, storageDB.OpenStorage(contract1))
 	assert.NoError(t, err)
 	tr.Update(makeHash("k1").Bytes(), makeHash("v1").Bytes())
 	tr.Update(makeHash("k2").Bytes(), makeHash("v2").Bytes())
@@ -849,21 +849,21 @@ func TestTrie_ShadowNodeRW(t *testing.T) {
 	assert.Equal(t, makeHash("v1").Bytes(), val)
 	assert.NoError(t, tr.TryDelete(makeHash("k1").Bytes()))
 
-	// TODO(0xbundle): need MPT support commit with shadow node
+	// TODO(0xbundler): need MPT support commit with shadow node
 	//nextRoot, _, err := tr.Commit(nil)
 	//assert.NoError(t, err)
-	//assert.NoError(t, storageRW.Commit(common.Big1, blockRoot1))
+	//assert.NoError(t, storageDB.Commit(common.Big1, blockRoot1))
 
 	// reload
-	//storageRW, err = NewShadowNodeStorageRW(tree, blockRoot1)
+	//storageDB, err = NewShadowNodestorageDB(tree, blockRoot1)
 	//assert.NoError(t, err)
-	//tr, err = NewStorageSecure(types.StateEpoch(2), nextRoot, database, storageRW.OpenStorage(contract1))
+	//tr, err = NewStorageSecure(types.StateEpoch(2), nextRoot, database, storageDB.OpenStorage(contract1))
 	//assert.NoError(t, err)
 	//val, err = tr.TryGet(makeHash("k2").Bytes())
 	//assert.NoError(t, err)
 	//assert.Equal(t, makeHash("v2").Bytes(), val)
 	//// check expired
-	//tr, err = NewStorageSecure(types.StateEpoch(3), nextRoot, database, storageRW.OpenStorage(contract1))
+	//tr, err = NewStorageSecure(types.StateEpoch(3), nextRoot, database, storageDB.OpenStorage(contract1))
 	//assert.NoError(t, err)
 	//val, err = tr.TryGet(makeHash("k2").Bytes())
 	//assert.Error(t, err)


### PR DESCRIPTION
### Description

support shadow node history store & query, and add more UTs.

### Changes

Notable changes: 
* rawdb: handle shadow node history & changeSet & plainState; 
* trie/shadownode: support shadow node history store & query;
* trie/shadownode_difflayer: support diff layers flatten to DB;
* trie/shadownode: add more UTs;
