### PR TITLE
trie/shadownode: support shadow node hash calculation;

### DIFF
--- a/trie/node.go
+++ b/trie/node.go
@@ -71,10 +71,19 @@ type (
 )
 
 type rootNode struct {
-	Epoch      types.StateEpoch
-	TrieHash   common.Hash
-	ShadowHash common.Hash
-	flags      nodeFlag `rlp:"-" json:"-"`
+	Epoch          types.StateEpoch
+	TrieRoot       common.Hash
+	ShadowTreeRoot common.Hash
+	flags          nodeFlag `rlp:"-" json:"-"`
+}
+
+func newEpoch0RootNode(trieRoot common.Hash) *rootNode {
+	return &rootNode{
+		Epoch:          types.StateEpoch0,
+		TrieRoot:       trieRoot,
+		ShadowTreeRoot: emptyRoot,
+		flags:          nodeFlag{dirty: true},
+	}
 }
 
 func (n *rootNode) cache() (hashNode, bool) {
@@ -86,7 +95,7 @@ func (n *rootNode) encode(w rlp.EncoderBuffer) {
 }
 
 func (n *rootNode) fstring(s string) string {
-	return fmt.Sprintf("{%v: %x: %x} ", n.Epoch, n.TrieHash, n.ShadowHash)
+	return fmt.Sprintf("{%v: %x: %x} ", n.Epoch, n.TrieRoot, n.ShadowTreeRoot)
 }
 
 func (n *rootNode) nodeType() int {

--- a/trie/node_test.go
+++ b/trie/node_test.go
@@ -103,18 +103,18 @@ func TestRootNodeEncodeDecode(t *testing.T) {
 	}{
 		{
 			r: &rootNode{
-				Epoch:      100,
-				TrieHash:   makeHash("t1"),
-				ShadowHash: makeHash("s1"),
-				flags:      nodeFlag{hash: makeHash("h1").Bytes()},
+				Epoch:          100,
+				TrieRoot:       makeHash("t1"),
+				ShadowTreeRoot: makeHash("s1"),
+				flags:          nodeFlag{hash: makeHash("h1").Bytes()},
 			},
 		},
 		{
 			r: &rootNode{
-				Epoch:      0,
-				TrieHash:   common.Hash{},
-				ShadowHash: common.Hash{},
-				flags:      nodeFlag{hash: makeHash("h1").Bytes()},
+				Epoch:          0,
+				TrieRoot:       common.Hash{},
+				ShadowTreeRoot: common.Hash{},
+				flags:          nodeFlag{hash: makeHash("h1").Bytes()},
 			},
 		},
 	}

--- a/trie/proof_test.go
+++ b/trie/proof_test.go
@@ -1273,7 +1273,7 @@ func randBytes(n int) []byte {
 
 func nonRandomTrie(n int) (*Trie, map[string]*kv) {
 	trie := new(Trie)
-	trie.isStorageTrie = true
+	trie.useShadowTree = true
 	trie.currentEpoch = 10 // TODO (asyukii): might need to change this
 	vals := make(map[string]*kv)
 	max := uint64(0xffffffffffffffff)

--- a/trie/shadow_node.go
+++ b/trie/shadow_node.go
@@ -13,23 +13,21 @@ import (
 )
 
 type shadowExtensionNode struct {
-	ShadowHash common.Hash
-	Epoch      types.StateEpoch
+	ShadowHash *common.Hash
 }
 
-func NewShadowExtensionNode(hash common.Hash, epoch types.StateEpoch) shadowExtensionNode {
+func NewShadowExtensionNode(hash *common.Hash) shadowExtensionNode {
 	return shadowExtensionNode{
 		ShadowHash: hash,
-		Epoch:      epoch,
 	}
 }
 
 type shadowBranchNode struct {
-	ShadowHash common.Hash
+	ShadowHash *common.Hash
 	EpochMap   [16]types.StateEpoch
 }
 
-func NewShadowBranchNode(hash common.Hash, epochMap [16]types.StateEpoch) shadowBranchNode {
+func NewShadowBranchNode(hash *common.Hash, epochMap [16]types.StateEpoch) shadowBranchNode {
 	return shadowBranchNode{hash, epochMap}
 }
 


### PR DESCRIPTION
### Description

support shadow node hash calculation, opt some trie fields.

### Changes

Notable changes: 
* trie/shadownode: support shadow node hash calculation