### PR TITLE
fix: opt & fix some issues to support estimateWitness & revive expired state

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -670,6 +670,9 @@ func (b *SimulatedBackend) EstimateGasAndReviveState(ctx context.Context, call e
 					if err != nil {
 						return true, nil, isExpiredError, err
 					}
+					if len(proof) == 0 {
+						continue
+					}
 					addressToProofMap[stateErr.Addr] = append(addressToProofMap[stateErr.Addr], types.MPTProof{
 						RootKeyHex: stateErr.Path,
 						Proof:      proof,

--- a/accounts/external/backend.go
+++ b/accounts/external/backend.go
@@ -216,7 +216,7 @@ func (api *ExternalSigner) SignTx(account accounts.Account, tx *types.Transactio
 		From:  common.NewMixedcaseAddress(account.Address),
 	}
 	switch tx.Type() {
-	case types.LegacyTxType, types.AccessListTxType:
+	case types.LegacyTxType, types.ReviveStateTxType, types.AccessListTxType:
 		args.GasPrice = (*hexutil.Big)(tx.GasPrice())
 	case types.DynamicFeeTxType:
 		args.MaxFeePerGas = (*hexutil.Big)(tx.GasFeeCap())

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -262,7 +262,7 @@ func New(
 		signatures:      signatures,
 		validatorSetABI: vABI,
 		slashABI:        sABI,
-		signer:          types.NewEIP155Signer(chainConfig.ChainID),
+		signer:          types.NewBEP215Signer(chainConfig.ChainID),
 	}
 
 	return c

--- a/core/state/errors.go
+++ b/core/state/errors.go
@@ -52,5 +52,5 @@ func NewInsertExpiredStateError(addr common.Address, key common.Hash, err *trie.
 }
 
 func (e *ExpiredStateError) Error() string {
-	return fmt.Sprintf("Access expired state, addr: %v, key: %v, epoch: %v, reason: %v", e.Addr, e.Key, e.Epoch, e.reason)
+	return fmt.Sprintf("Access expired state, addr: %v, path: %v, key: %v, epoch: %v, reason: %v", e.Addr, e.Path, e.Key, e.Epoch, e.reason)
 }

--- a/core/state/errors.go
+++ b/core/state/errors.go
@@ -18,7 +18,7 @@ type ExpiredStateError struct {
 	reason   string
 }
 
-func NewPlainExpiredStateError(addr common.Address, key common.Hash, epoch types.StateEpoch) *ExpiredStateError {
+func NewSnapExpiredStateError(addr common.Address, key common.Hash, epoch types.StateEpoch) *ExpiredStateError {
 	return &ExpiredStateError{
 		Addr:     addr,
 		Key:      key,

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -162,7 +162,7 @@ func NewWithStateEpoch(config *params.ChainConfig, targetBlock *big.Int, root co
 		return nil, err
 	}
 
-	log.Info("NewWithStateEpoch", "targetBlock", targetBlock, "targetEpoch", targetEpoch, "root", root)
+	log.Debug("NewWithStateEpoch", "targetBlock", targetBlock, "targetEpoch", targetEpoch, "root", root)
 	// init target block and shadowNodeRW
 	stateDB.targetBlk = targetBlock
 	stateDB.shadowNodeDB, err = trie.NewShadowNodeDatabase(sntree, targetBlock, root)
@@ -1652,7 +1652,7 @@ func (s *StateDB) Commit(failPostCommitFunc func(), postCommitFuncs ...func() er
 		root = s.expectedRoot
 	}
 
-	log.Info("statedb commit", "originalRoot", s.originalRoot, "root", root, "targetBlk", s.targetBlk, "targetEpoch", s.targetEpoch)
+	log.Debug("statedb commit", "originalRoot", s.originalRoot, "root", root, "targetBlk", s.targetBlk, "targetEpoch", s.targetEpoch)
 	if s.shadowNodeDB != nil {
 		if err := s.shadowNodeDB.Commit(s.targetBlk, root); err != nil {
 			return common.Hash{}, nil, err

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -642,7 +642,10 @@ func (pool *TxPool) local() map[common.Address]types.Transactions {
 func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	// Accept only legacy transactions until EIP-2718/2930 activates.
 	if !pool.eip2718 && tx.Type() != types.LegacyTxType {
-		return ErrTxTypeNotSupported
+		// If isElwood, accept types.ReviveStateTxType
+		if !(pool.isElwood || tx.Type() == types.ReviveStateTxType) {
+			return ErrTxTypeNotSupported
+		}
 	}
 	// Reject dynamic fee transactions until EIP-1559 activates.
 	if !pool.eip1559 && tx.Type() == types.DynamicFeeTxType {

--- a/core/types/receipt.go
+++ b/core/types/receipt.go
@@ -198,7 +198,7 @@ func (r *Receipt) DecodeRLP(s *rlp.Stream) error {
 			return errEmptyTypedReceipt
 		}
 		r.Type = b[0]
-		if r.Type == AccessListTxType || r.Type == DynamicFeeTxType {
+		if r.Type == AccessListTxType || r.Type == DynamicFeeTxType || r.Type == ReviveStateTxType {
 			var dec receiptRLP
 			if err := rlp.DecodeBytes(b[1:], &dec); err != nil {
 				return err
@@ -234,7 +234,7 @@ func (r *Receipt) decodeTyped(b []byte) error {
 		return errEmptyTypedReceipt
 	}
 	switch b[0] {
-	case DynamicFeeTxType, AccessListTxType:
+	case DynamicFeeTxType, AccessListTxType, ReviveStateTxType:
 		var data receiptRLP
 		err := rlp.DecodeBytes(b[1:], &data)
 		if err != nil {
@@ -406,6 +406,9 @@ func (rs Receipts) EncodeIndex(i int, w *bytes.Buffer) {
 		rlp.Encode(w, data)
 	case DynamicFeeTxType:
 		w.WriteByte(DynamicFeeTxType)
+		rlp.Encode(w, data)
+	case ReviveStateTxType:
+		w.WriteByte(ReviveStateTxType)
 		rlp.Encode(w, data)
 	default:
 		// For unsupported types, write nothing. Since this is for

--- a/core/types/transaction_signing.go
+++ b/core/types/transaction_signing.go
@@ -40,6 +40,8 @@ type sigCache struct {
 func MakeSigner(config *params.ChainConfig, blockNumber *big.Int) Signer {
 	var signer Signer
 	switch {
+	case config.IsClaude(blockNumber):
+		signer = NewBEP215Signer(config.ChainID)
 	case config.IsLondon(blockNumber):
 		signer = NewLondonSigner(config.ChainID)
 	case config.IsBerlin(blockNumber):
@@ -63,6 +65,9 @@ func MakeSigner(config *params.ChainConfig, blockNumber *big.Int) Signer {
 // have the current block number available, use MakeSigner instead.
 func LatestSigner(config *params.ChainConfig) Signer {
 	if config.ChainID != nil {
+		if config.ClaudeBlock != nil {
+			return NewBEP215Signer(config.ChainID)
+		}
 		if config.LondonBlock != nil {
 			return NewLondonSigner(config.ChainID)
 		}

--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -22,8 +22,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/ethereum/go-ethereum/log"
-
 	"github.com/holiman/uint256"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -264,13 +262,7 @@ func (evm *EVM) Call(caller ContractRef, addr common.Address, input []byte, gas 
 		// TODO: consider clearing up unused snapshots:
 		//} else {
 		//	evm.StateDB.DiscardSnapshot(snapshot)
-
-		errors := evm.Errors()
-		for _, e := range errors {
-			log.Error("call err", "addr", addr, "from", caller.Address(), "err", e.Error())
-		}
 	}
-
 	return ret, gas, err
 }
 

--- a/core/vm/gas_table.go
+++ b/core/vm/gas_table.go
@@ -19,6 +19,8 @@ package vm
 import (
 	"errors"
 
+	"github.com/ethereum/go-ethereum/core/state"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/params"
@@ -140,6 +142,10 @@ func gasSStore(evm *EVM, contract *Contract, stack *Stack, mem *Memory, memorySi
 	}
 	original, err := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
 	if err != nil {
+		// if origin is expired and revive, just small gas
+		if _, ok := err.(*state.ExpiredStateError); ok {
+			return params.NetSstoreDirtyGas, nil
+		}
 		return 0, err
 	}
 	if original == current {
@@ -201,6 +207,10 @@ func gasSStoreEIP2200(evm *EVM, contract *Contract, stack *Stack, mem *Memory, m
 	}
 	original, err := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
 	if err != nil {
+		// if origin is expired and revive, just small gas
+		if _, ok := err.(*state.ExpiredStateError); ok {
+			return params.NetSstoreDirtyGas, nil
+		}
 		return 0, err
 	}
 	if original == current {

--- a/core/vm/operations_acl.go
+++ b/core/vm/operations_acl.go
@@ -19,6 +19,8 @@ package vm
 import (
 	"errors"
 
+	"github.com/ethereum/go-ethereum/core/state"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/params"
@@ -61,6 +63,10 @@ func makeGasSStoreFunc(clearingRefund uint64) gasFunc {
 		}
 		original, err := evm.StateDB.GetCommittedState(contract.Address(), x.Bytes32())
 		if err != nil {
+			// if origin is expired and revive, just small gas
+			if _, ok := err.(*state.ExpiredStateError); ok {
+				return params.NetSstoreDirtyGas, nil
+			}
 			return 0, err
 		}
 		if original == current {

--- a/trie/database.go
+++ b/trie/database.go
@@ -28,7 +28,6 @@ import (
 	"github.com/VictoriaMetrics/fastcache"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/rawdb"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
@@ -102,10 +101,8 @@ type Database struct {
 // in the same cache fields).
 type rawNode []byte
 
-func (n rawNode) cache() (hashNode, bool)         { panic("this should never end up in a live trie") }
-func (n rawNode) fstring(ind string) string       { panic("this should never end up in a live trie") }
-func (n rawNode) setEpoch(epcoh types.StateEpoch) { panic("this should never end up in a live trie") }
-func (n rawNode) getEpoch() types.StateEpoch      { panic("this should never end up in a live trie") }
+func (n rawNode) cache() (hashNode, bool)   { panic("this should never end up in a live trie") }
+func (n rawNode) fstring(ind string) string { panic("this should never end up in a live trie") }
 
 func (n rawNode) EncodeRLP(w io.Writer) error {
 	_, err := w.Write(n)
@@ -123,10 +120,6 @@ type rawFullNode [17]node
 
 func (n rawFullNode) cache() (hashNode, bool)   { panic("this should never end up in a live trie") }
 func (n rawFullNode) fstring(ind string) string { panic("this should never end up in a live trie") }
-func (n rawFullNode) setEpoch(epcoh types.StateEpoch) {
-	panic("this should never end up in a live trie")
-}
-func (n rawFullNode) getEpoch() types.StateEpoch { panic("this should never end up in a live trie") }
 
 func (n rawFullNode) nodeType() int {
 	return rawFullNodeType
@@ -148,10 +141,6 @@ type rawShortNode struct {
 
 func (n rawShortNode) cache() (hashNode, bool)   { panic("this should never end up in a live trie") }
 func (n rawShortNode) fstring(ind string) string { panic("this should never end up in a live trie") }
-func (n rawShortNode) setEpoch(epoch types.StateEpoch) {
-	panic("this should never end up in a live trie")
-}
-func (n rawShortNode) getEpoch() types.StateEpoch { panic("this should never end up in a live trie") }
 
 func (n rawShortNode) nodeType() int {
 	return rawShortNodeType

--- a/trie/errors.go
+++ b/trie/errors.go
@@ -37,9 +37,15 @@ func (err *MissingNodeError) Error() string {
 }
 
 type ExpiredNodeError struct {
-	ExpiredNode node   // node of the expired node
-	Path        []byte // hex-encoded path to the expired node
-	Epoch       types.StateEpoch
+	Path  []byte // hex-encoded path to the expired node
+	Epoch types.StateEpoch
+}
+
+func NewExpiredNodeError(path []byte, epoch types.StateEpoch) error {
+	return &ExpiredNodeError{
+		Path:  path,
+		Epoch: epoch,
+	}
 }
 
 func (err *ExpiredNodeError) Error() string {

--- a/trie/hasher.go
+++ b/trie/hasher.go
@@ -141,17 +141,6 @@ func (h *hasher) hashFullNodeChildren(n *fullNode) (collapsed *fullNode, cached 
 	return collapsed, cached
 }
 
-// shadowExtendNodeToHash hash shadowExtendNode
-func (h *hasher) shadowExtendNodeToHash(n *shadowExtensionNode) *common.Hash {
-	if n.ShadowHash == nil {
-		return nil
-	}
-
-	n.encode(h.encbuf)
-	enc := h.encodedBytes()
-	return h.hashCommon(enc)
-}
-
 // shadowFullNodeToHash hash shadowBranchNode
 func (h *hasher) shadowBranchNodeToHash(n *shadowBranchNode) *common.Hash {
 	n.encode(h.encbuf)

--- a/trie/node.go
+++ b/trie/node.go
@@ -47,8 +47,6 @@ type node interface {
 	encode(w rlp.EncoderBuffer)
 	fstring(string) string
 	nodeType() int
-	setEpoch(epoch types.StateEpoch)
-	getEpoch() types.StateEpoch
 }
 
 type (
@@ -135,13 +133,8 @@ func (n valueNode) String() string  { return n.fstring("") }
 
 func (n *fullNode) setEpoch(epoch types.StateEpoch)  { n.epoch = epoch }
 func (n *shortNode) setEpoch(epoch types.StateEpoch) { n.epoch = epoch }
-func (n hashNode) setEpoch(epoch types.StateEpoch)   {}
-func (n valueNode) setEpoch(epoch types.StateEpoch)  {}
-
-func (n *fullNode) getEpoch() types.StateEpoch  { return n.epoch }
-func (n *shortNode) getEpoch() types.StateEpoch { return n.epoch }
-func (n hashNode) getEpoch() types.StateEpoch   { return 0 }
-func (n valueNode) getEpoch() types.StateEpoch  { return 0 }
+func (n *fullNode) getEpoch() types.StateEpoch       { return n.epoch }
+func (n *shortNode) getEpoch() types.StateEpoch      { return n.epoch }
 
 func (n *fullNode) fstring(ind string) string {
 	resp := fmt.Sprintf("[\n%s  ", ind)

--- a/trie/node.go
+++ b/trie/node.go
@@ -99,9 +99,8 @@ func (n *fullNode) ChildExpired(prefix []byte, index int, currentEpoch types.Sta
 	childEpoch := n.GetChildEpoch(index)
 	if types.EpochExpired(childEpoch, currentEpoch) {
 		return true, &ExpiredNodeError{
-			ExpiredNode: n.Children[index],
-			Path:        prefix,
-			Epoch:       childEpoch,
+			Path:  prefix,
+			Epoch: childEpoch,
 		}
 	}
 	return false, nil

--- a/trie/shadow_node.go
+++ b/trie/shadow_node.go
@@ -238,13 +238,13 @@ func NewShadowNodeDatabase(tree *ShadowNodeSnapTree, number *big.Int, blockRoot 
 		// try using default snap
 		if snap = tree.Snapshot(emptyRoot); snap == nil {
 			// open read only history
-			log.Info("NewShadowNodeDatabase use RO database", "number", number, "root", blockRoot)
+			log.Debug("NewShadowNodeDatabase use RO database", "number", number, "root", blockRoot)
 			return &ShadowNodeStorageRO{
 				diskdb: tree.DB(),
 				number: number,
 			}, nil
 		}
-		log.Info("NewShadowNodeDatabase use default database", "number", number, "root", blockRoot)
+		log.Debug("NewShadowNodeDatabase use default database", "number", number, "root", blockRoot)
 	}
 	return &ShadowNodeStorageRW{
 		snap:    snap,


### PR DESCRIPTION
### Description

fix: opt & fix some issues to support estimateWitness & revive expired state

### Changes

Notable changes: 
* signer: fix txpool, codec bug with new ReviveTx & BEP215Signer;
* state/state_object: recall dirty revive trie for accuracy expired info;
* vm/evm: fix sstore calculate expired state gas bug;
* ethapi/api: fix EstimateGasAndReviveState resolve witness issues;
* trie/trie: opt shadow hash calculation, recalloect branch node epoch map;
* trie/trie: keep as hashNode when meet expired node, opt expired node checking;
* trie/trie: fix expired check bug when child is nil;
* state/database: fix reuse trie with shadow nodes bug;
* state/state_object: opt snap state query, opt insert dup check;
* state/statedb: fix copy bugs;
* trie/trie: opt trie root epoch bug, remove node's epoch methods;
