### PR TITLE
fix: add parent expired check for inline prune

### DIFF
--- a/trie/database.go
+++ b/trie/database.go
@@ -578,7 +578,7 @@ func (db *Database) Dereference(root common.Hash, epoch types.StateEpoch) {
 }
 
 func checkBEP206PruneRule(childEpoch, parentEpoch, currEpoch types.StateEpoch) bool {
-	return types.EpochExpired(childEpoch, currEpoch) && (parentEpoch >= childEpoch+2)
+	return types.EpochExpired(childEpoch, currEpoch) && (types.EpochExpired(parentEpoch, currEpoch) || parentEpoch >= childEpoch+2)
 }
 
 // dereference is the private locked version of Dereference.


### PR DESCRIPTION
### Description

There's a case where if both parent and child nodes are expired, they will not be pruned.
Added a condition to prune the child node if the parent node is expired.
