### PR TITLE
fix(prune): storage trie now can be inline pruned

### DIFF
--- a/trie/committer.go
+++ b/trie/committer.go
@@ -120,15 +120,10 @@ func (c *committer) commit(n node, db *Database) (node, int, error) {
 		}
 		return collapsed, childCommitted, nil
 	case *rootNode:
-		log.Info("Committing root node")
-		hash, _ := cn.cache()
-		log.Info("Root node cache", "hash", hash)
 		collapsed := cn.copy()
 		hashedNode := c.store(collapsed, db)
 		if hn, ok := hashedNode.(hashNode); ok {
 			return hn, 1, nil
-		} else {
-			log.Info("Root node is not a hash node.")
 		}
 		return collapsed, 0, nil
 	case hashNode:
@@ -263,7 +258,7 @@ func estimateSize(n node) int {
 	case hashNode:
 		return 1 + len(n)
 	case *rootNode:
-		return 1 + len(n.cachedHash) + len(n.TrieRoot) + len(n.ShadowTreeRoot)
+		return 5 + len(n.TrieRoot) + len(n.ShadowTreeRoot)
 	default:
 		panic(fmt.Sprintf("node type %T", n))
 	}

--- a/trie/committer.go
+++ b/trie/committer.go
@@ -119,6 +119,18 @@ func (c *committer) commit(n node, db *Database) (node, int, error) {
 			return hn, childCommitted + 1, nil
 		}
 		return collapsed, childCommitted, nil
+	case *rootNode:
+		log.Info("Committing root node")
+		hash, _ := cn.cache()
+		log.Info("Root node cache", "hash", hash)
+		collapsed := cn.copy()
+		hashedNode := c.store(collapsed, db)
+		if hn, ok := hashedNode.(hashNode); ok {
+			return hn, 1, nil
+		} else {
+			log.Info("Root node is not a hash node.")
+		}
+		return collapsed, 0, nil
 	case hashNode:
 		return cn, 0, nil
 	default:
@@ -250,6 +262,8 @@ func estimateSize(n node) int {
 		return 1 + len(n)
 	case hashNode:
 		return 1 + len(n)
+	case *rootNode:
+		return 1 + len(n.cachedHash) + len(n.TrieRoot) + len(n.ShadowTreeRoot)
 	default:
 		panic(fmt.Sprintf("node type %T", n))
 	}

--- a/trie/database.go
+++ b/trie/database.go
@@ -229,6 +229,8 @@ func forGatherChildren(n node, onChild func(hash common.Hash)) {
 		}
 	case hashNode:
 		onChild(common.BytesToHash(n))
+	case *rootNode:
+		onChild(n.TrieRoot)
 	case valueNode, nil, rawNode:
 	default:
 		panic(fmt.Sprintf("unknown node type: %T", n))
@@ -256,7 +258,7 @@ func simplifyNode(n node) node {
 		}
 		return node
 
-	case valueNode, hashNode, rawNode:
+	case valueNode, hashNode, rawNode, *rootNode:
 		return n
 
 	default:
@@ -292,7 +294,7 @@ func expandNode(hash hashNode, n node) node {
 		}
 		return node
 
-	case valueNode, hashNode:
+	case valueNode, hashNode, *rootNode:
 		return n
 
 	default:

--- a/trie/node.go
+++ b/trie/node.go
@@ -38,6 +38,7 @@ const (
 	rawNodeType
 	rawShortNodeType
 	rawFullNodeType
+	rootNodeType
 )
 
 var indices = []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f", "[17]"}
@@ -218,6 +219,9 @@ func decodeNodeUnsafe(hash, buf []byte) (node, error) {
 	case 17:
 		n, err := decodeFull(hash, elems)
 		return n, wrapError(err, "full")
+	case 3:
+		n, err := decodeRootNode(buf)
+		return n, wrapError(err, "root")
 	default:
 		return nil, fmt.Errorf("invalid number of list elements: %v", c)
 	}

--- a/trie/node.go
+++ b/trie/node.go
@@ -220,7 +220,7 @@ func decodeNodeUnsafe(hash, buf []byte) (node, error) {
 		n, err := decodeFull(hash, elems)
 		return n, wrapError(err, "full")
 	case 3:
-		n, err := decodeRootNode(buf)
+		n, err := DecodeRootNode(buf)
 		return n, wrapError(err, "root")
 	default:
 		return nil, fmt.Errorf("invalid number of list elements: %v", c)

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -70,7 +70,7 @@ func NewSecureWithShadowNodes(curEpoch types.StateEpoch, root common.Hash, db *D
 		panic("trie.NewSecure called without a database")
 	}
 
-	rn, err := resolveRootNode(sndb, root)
+	rn, err := resolveRootNodeTrieDb(db, root)
 	if err != nil {
 		return nil, err
 	}

--- a/trie/shadow_node.go
+++ b/trie/shadow_node.go
@@ -3,6 +3,7 @@ package trie
 import (
 	"bytes"
 	"errors"
+	"fmt"
 	"math/big"
 	"sync"
 
@@ -41,9 +42,28 @@ func newRootNode(epoch types.StateEpoch, trieRoot, shadowTreeRoot common.Hash) *
 	n.resolveCache()
 	return n
 }
+
+func (n *rootNode) copy() *rootNode { copy := *n; return &copy }
+
 func (n *rootNode) encode(w rlp.EncoderBuffer) {
 	rlp.Encode(w, n)
 }
+
+func (n *rootNode) cache() (hashNode, bool) { return n.cachedHash[:], true }
+
+func (n *rootNode) setEpoch(epoch types.StateEpoch) { n.Epoch = epoch }
+func (n *rootNode) getEpoch() types.StateEpoch      { return n.Epoch }
+
+func (n *rootNode) String() string { return n.fstring("") }
+
+func (n *rootNode) fstring(ind string) string {
+	return fmt.Sprintf("rootNode{epoch:%d, trieRoot:%s, shadowTreeRoot:%s}", n.Epoch, n.TrieRoot, n.ShadowTreeRoot)
+}
+
+func (n *rootNode) nodeType() int {
+	return rootNodeType
+}
+
 func (n *rootNode) resolveCache() {
 	buf := rlp.NewEncoderBuffer(nil)
 	n.encode(buf)

--- a/trie/shadow_node.go
+++ b/trie/shadow_node.go
@@ -77,7 +77,7 @@ func (n *rootNode) resolveCache() {
 	returnHasherToPool(h)
 }
 
-func decodeRootNode(enc []byte) (*rootNode, error) {
+func DecodeRootNode(enc []byte) (*rootNode, error) {
 	n := &rootNode{}
 	if err := rlp.DecodeBytes(enc, n); err != nil {
 		return nil, err

--- a/trie/shadow_node_test.go
+++ b/trie/shadow_node_test.go
@@ -234,7 +234,7 @@ func TestRootNode_encodeDecode(t *testing.T) {
 		item.n.encode(buf)
 		enc := buf.ToBytes()
 
-		rn, err := decodeRootNode(enc)
+		rn, err := DecodeRootNode(enc)
 		assert.NoError(t, err)
 		if !item.isEqual {
 			assert.NotEqual(t, item.n, rn)

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -1227,7 +1227,7 @@ func resolveRootNode(sndb ShadowNodeStorage, root common.Hash) (*rootNode, error
 	if len(val) == 0 {
 		return newEpoch0RootNode(root), nil
 	}
-	n, err := decodeRootNode(val)
+	n, err := DecodeRootNode(val)
 	if err != nil {
 		return nil, err
 	}

--- a/trie/trie_test.go
+++ b/trie/trie_test.go
@@ -617,7 +617,7 @@ func TestTryRevive(t *testing.T) {
 			assert.Equal(t, oriRootHash, currRootHash, "Root hash mismatch, got %x, expected %x", currRootHash, oriRootHash)
 
 			// Reset trie
-			trie, _ = nonRandomTrie(500)
+			trie, _ = nonRandomTrieWithShadowNodes(500)
 		}
 	}
 }
@@ -664,7 +664,7 @@ func TestTryReviveCustomData(t *testing.T) {
 
 			// Verify root hash
 			currRootHash := trie.Hash()
-			assert.Equal(t, oriRootHash, currRootHash, "Root hash mismatch, got %x, expected %x", currRootHash, oriRootHash, key, prefixKey)
+			assert.Equal(t, oriRootHash, currRootHash, "Root hash mismatch, got %x, expected %x, key %x, prefixKey %x", currRootHash, oriRootHash, key, prefixKey)
 
 			// Reset trie
 			trie = createCustomTrie(data, 10)
@@ -995,11 +995,12 @@ func TestTrie_ShadowHash_case2(t *testing.T) {
 	assert.NoError(t, err)
 
 	sndb := storageDB.OpenStorage(contract1)
-	enc, err := sndb.Get(ShadowTreeRootNodePath)
-	assert.NoError(t, err)
-	r1, err := decodeRootNode(enc)
-	assert.NoError(t, err)
-	tr, err = NewWithShadowNode(11, r1, database, sndb)
+	rn := tr.db.node(newRoot)
+	// enc, err := sndb.Get(ShadowTreeRootNodePath)
+	// assert.NoError(t, err)
+	// r1, err := decodeRootNode(enc)
+	// assert.NoError(t, err)
+	tr, err = NewWithShadowNode(11, rn.(*rootNode), database, sndb)
 	assert.NoError(t, err)
 	_, err = tr.TryGet(common.Hex2Bytes("223dffac48c9ce11eb8dd110a36c55aa7f51fd1ab98b4c9b8ebe4decfd72f2288"))
 	assert.NoError(t, err)


### PR DESCRIPTION
### Description
Fix inline prune problem where storage trie couldn't be pruned properly.

### Changes

Notable changes: 
* RootNode implements node interface
* RootNode is stored in TrieDb instead of ShadowNodeDb
* Expired nodes with epoch 0 will not be inline-pruned to avoid pruning account trie nodes. This is a temporary fix and can be refactored in the future
* cachedNode will store RootNode
