### PR TITLE
rpc(revive): get from latest block num

### DIFF
--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -800,7 +800,12 @@ func (s *stateObject) fetchExpiredFromRemote(prefixKey []byte, key common.Hash, 
 
 	// if no prefix, query from revive trie, got the newest expired info
 	if resolvePath {
-		_, err := tr.GetStorage(s.address, key.Bytes())
+		val, err := tr.GetStorage(s.address, key.Bytes())
+		// TODO(asyukii): temporary fix snap expired, but trie not expire, may investigate more later.
+		if val != nil {
+			s.pendingReviveState[string(crypto.Keccak256(key[:]))] = common.BytesToHash(val)
+			return val, nil
+		}
 		enErr, ok := err.(*trie.ExpiredNodeError)
 		if !ok {
 			return nil, fmt.Errorf("cannot find expired state from trie, err: %v", err)

--- a/core/types/revive_state.go
+++ b/core/types/revive_state.go
@@ -1,7 +1,16 @@
 package types
 
+import (
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
 type ReviveStorageProof struct {
 	Key       string   `json:"key"`
 	PrefixKey string   `json:"prefixKey"`
 	Proof     []string `json:"proof"`
+}
+
+type ReviveResult struct {
+	StorageProof []ReviveStorageProof `json:"storageProof"`
+	BlockNum     hexutil.Uint64       `json:"blockNum"`
 }

--- a/ethclient/gethclient/gethclient_test.go
+++ b/ethclient/gethclient/gethclient_test.go
@@ -242,21 +242,23 @@ func testGetProof(t *testing.T, client *rpc.Client) {
 func testGetStorageReviveProof(t *testing.T, client *rpc.Client) {
 	ec := New(client)
 	result, err := ec.GetStorageReviveProof(context.Background(), testAddr, []string{testSlot.String()}, []string{""}, common.Hash{})
+	proofs := result.StorageProof
+
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	// test storage
-	if len(result) != 1 {
-		t.Fatalf("invalid storage proof, want 1 proof, got %v proof(s)", len(result))
+	if len(proofs) != 1 {
+		t.Fatalf("invalid storage proof, want 1 proof, got %v proof(s)", len(proofs))
 	}
 
-	if result[0].Key != testSlot.String() {
-		t.Fatalf("invalid storage proof key, want: %q, got: %q", testSlot.String(), result[0].Key)
+	if proofs[0].Key != testSlot.String() {
+		t.Fatalf("invalid storage proof key, want: %q, got: %q", testSlot.String(), proofs[0].Key)
 	}
 
-	if result[0].PrefixKey != "" {
-		t.Fatalf("invalid storage proof prefix key, want: %q, got: %q", "", result[0].PrefixKey)
+	if proofs[0].PrefixKey != "" {
+		t.Fatalf("invalid storage proof prefix key, want: %q, got: %q", "", proofs[0].PrefixKey)
 	}
 }
 

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -797,11 +797,12 @@ func (s *BlockChainAPI) GetStorageReviveProof(ctx context.Context, stateRoot com
 	}
 
 	stateDb, header, _ = s.b.StateAndHeaderByNumber(ctx, rpc.LatestBlockNumber)
-	storageTrie, err = s.b.StorageTrie(stateRoot, address, root)
+	blockNum = hexutil.Uint64(header.Number.Uint64())
 
+	storageTrie, err = s.b.StorageTrie(stateRoot, address, root)
 	if (err != nil || storageTrie == nil) && stateDb != nil {
 		storageTrie, err = openStorageTrie(stateDb, header, address)
-		blockNum = hexutil.Uint64(header.Number.Uint64())
+		log.Info("GetStorageReviveProof from latest block number", "blockNum", blockNum, "blockHash", header.Hash().Hex())
 	}
 
 	if err != nil || storageTrie == nil {

--- a/trie/proof.go
+++ b/trie/proof.go
@@ -120,7 +120,6 @@ func (t *StateTrie) Prove(key []byte, proofDb ethdb.KeyValueWriter) error {
 // it.
 func (t *Trie) traverseNodes(tn node, prefixKey, suffixKey []byte, nodes *[]node, epoch types.StateEpoch, updateEpoch bool) (node, error) {
 	for len(suffixKey) > 0 && tn != nil {
-		log.Info("traverseNodes loop", "prefix", common.Bytes2Hex(prefixKey), "suffix", common.Bytes2Hex(suffixKey), "n", tn.fstring(""))
 		switch n := tn.(type) {
 		case *shortNode:
 			if len(suffixKey) >= len(n.Key) && bytes.Equal(n.Key, suffixKey[:len(n.Key)]) {

--- a/trie/trie.go
+++ b/trie/trie.go
@@ -1238,8 +1238,8 @@ func (t *Trie) tryRevive(n node, key []byte, targetPrefixKey []byte, nub MPTProo
 			n1 = n1.copy()
 			n1.Val = newnode
 			n1.flags = t.newFlag()
-			tryUpdateNodeEpoch(nub.n1, t.currentEpoch)
-			renew, _, err := t.updateChildNodeEpoch(nub.n1, key, pos, t.currentEpoch)
+			tryUpdateNodeEpoch(n1, t.currentEpoch)
+			renew, _, err := t.updateChildNodeEpoch(n1, key, pos, t.currentEpoch)
 			if err != nil {
 				return nil, false, fmt.Errorf("update child node epoch while reviving failed, err: %v", err)
 			}


### PR DESCRIPTION
### Description
Modify `eth_getStorageReviveProof` to load storage trie using the latest block number if cannot load the contract trie directly from the RPC requests parameters.

### Rationale
If localDB is ahead of remoteDB, remoteDB may not be able to find the contract trie, causing missing trie node error. 