### PR TITLE
core/state, trie, api: batch mode revive, remoteDB cache, unit tests

### DIFF
--- a/cmd/geth/config.go
+++ b/cmd/geth/config.go
@@ -32,6 +32,7 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/scwallet"
 	"github.com/ethereum/go-ethereum/accounts/usbwallet"
 	"github.com/ethereum/go-ethereum/cmd/utils"
+	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/ethereum/go-ethereum/internal/ethapi"
 	"github.com/ethereum/go-ethereum/internal/flags"
@@ -272,8 +273,14 @@ func applyMetricConfig(ctx *cli.Context, cfg *gethConfig) {
 }
 
 func applyStateExpiryConfig(ctx *cli.Context, cfg *gethConfig) {
+
 	if ctx.IsSet(utils.StateExpiryEnableFlag.Name) {
-		cfg.Eth.StateExpiryEnable = ctx.Bool(utils.StateExpiryEnableFlag.Name)
+		enableStateExpiry := ctx.Bool(utils.StateExpiryEnableFlag.Name)
+		if enableStateExpiry && ctx.IsSet(utils.StateSchemeFlag.Name) && ctx.String(utils.StateSchemeFlag.Name) == rawdb.HashScheme {
+			log.Warn("State expiry is not supported with hash scheme. Disabling state expiry")
+			enableStateExpiry = false
+		}
+		cfg.Eth.StateExpiryEnable = enableStateExpiry
 	}
 	if ctx.IsSet(utils.StateExpiryFullStateEndpointFlag.Name) {
 		cfg.Eth.StateExpiryFullStateEndpoint = ctx.String(utils.StateExpiryFullStateEndpointFlag.Name)

--- a/core/state/state_object.go
+++ b/core/state/state_object.go
@@ -484,7 +484,7 @@ func (s *stateObject) updateTrie() (Trie, error) {
 					continue
 				}
 				if _, err = fetchExpiredStorageFromRemote(s.db.fullStateDB, s.db.originalRoot, s.address, s.data.Root, tr, enErr.Path, key); err != nil {
-					s.db.setError(fmt.Errorf("state object pendingFutureReviveState fetchExpiredStorageFromRemote err, contract: %v, key: %v, err: %v", s.address, key, err))
+					s.db.setError(fmt.Errorf("state object pendingFutureReviveState fetchExpiredStorageFromRemote err, contract: %v, key: %v, path: %v, err: %v", s.address, key, enErr.Path, err))
 				}
 			}
 		}

--- a/ethdb/fullstatedb.go
+++ b/ethdb/fullstatedb.go
@@ -72,7 +72,7 @@ func (f *FullStateRPCServer) GetStorageReviveProof(stateRoot common.Hash, accoun
 	uncachedKeys := make([]string, 0, len(keys))
 	ret := make([]types.ReviveStorageProof, 0, len(keys))
 	for i, key := range keys {
-		val, ok := f.cache.Get(proofCacheKey(account, root, prefixKeys[i], key))
+		val, ok := f.cache.Get(ProofCacheKey(account, root, prefixKeys[i], key))
 		log.Debug("GetStorageReviveProof hit cache", "account", account, "key", key, "ok", ok)
 		if !ok {
 			uncachedPrefixKeys = append(uncachedPrefixKeys, prefixKeys[i])
@@ -98,14 +98,14 @@ func (f *FullStateRPCServer) GetStorageReviveProof(stateRoot common.Hash, accoun
 
 	// add to cache
 	for _, proof := range proofs {
-		f.cache.Add(proofCacheKey(account, root, proof.PrefixKey, proof.Key), proof)
+		f.cache.Add(ProofCacheKey(account, root, proof.PrefixKey, proof.Key), proof)
 	}
 
 	ret = append(ret, proofs...)
 	return ret, err
 }
 
-func proofCacheKey(account common.Address, root common.Hash, prefix, key string) string {
+func ProofCacheKey(account common.Address, root common.Hash, prefix, key string) string {
 	buf := bytes.NewBuffer(make([]byte, 0, 67+len(prefix)+len(key)))
 	buf.Write(account[:])
 	buf.WriteByte('$')


### PR DESCRIPTION
### Description
- Subfetcher now revive states in batches instead of individually
- Add trie revive unit tests
- RemoteDB will cache storage proof requests
- User can only enable state expiry with PBSS
