### PR TITLE
State expiry mvp0.1: performance opt, support snapshot prunelevel1

### DIFF
--- a/cmd/geth/main.go
+++ b/cmd/geth/main.go
@@ -225,6 +225,7 @@ var (
 		utils.StateExpiryStateEpochPeriodFlag,
 		utils.StateExpiryEnableLocalReviveFlag,
 		utils.StateExpiryEnableRemoteModeFlag,
+		utils.StateExpiryPruneLevelFlag,
 	}
 )
 

--- a/cmd/geth/snapshot.go
+++ b/cmd/geth/snapshot.go
@@ -455,12 +455,12 @@ func pruneState(ctx *cli.Context) error {
 		StateExpiryCfg:      cfg.Eth.StateExpiryCfg,
 	}
 	prunerconfig := pruner.Config{
-		Datadir:           stack.ResolvePath(""),
-		BloomSize:         ctx.Uint64(utils.BloomFilterSizeFlag.Name),
-		EnableStateExpiry: cfg.Eth.StateExpiryCfg.EnableExpiry(),
-		ChainConfig:       chainConfig,
-		CacheConfig:       cacheConfig,
-		MaxExpireThreads:  ctx.Uint64(utils.StateExpiryMaxThreadFlag.Name),
+		Datadir:          stack.ResolvePath(""),
+		BloomSize:        ctx.Uint64(utils.BloomFilterSizeFlag.Name),
+		ExpiryCfg:        cfg.Eth.StateExpiryCfg,
+		ChainConfig:      chainConfig,
+		CacheConfig:      cacheConfig,
+		MaxExpireThreads: ctx.Uint64(utils.StateExpiryMaxThreadFlag.Name),
 	}
 	pruner, err := pruner.NewPruner(chaindb, prunerconfig, ctx.Uint64(utils.TriesInMemoryFlag.Name))
 	if err != nil {

--- a/core/state/snapshot/snapshot_expire.go
+++ b/core/state/snapshot/snapshot_expire.go
@@ -5,31 +5,18 @@ import (
 	"github.com/ethereum/go-ethereum/core/rawdb"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethdb"
-	"github.com/ethereum/go-ethereum/log"
+)
+
+const (
+	ContractSnapshotAvgSize = 17 // This is an estimated value
 )
 
 // ShrinkExpiredLeaf tool function for snapshot kv prune
-func ShrinkExpiredLeaf(writer ethdb.KeyValueWriter, reader ethdb.KeyValueReader, accountHash common.Hash, storageHash common.Hash, epoch types.StateEpoch, scheme string) (int64, error) {
-	switch scheme {
-	case rawdb.HashScheme:
-		//cannot prune snapshot in hbss, because it will used for trie prune, but it's ok in pbss.
-	case rawdb.PathScheme:
-		val := rawdb.ReadStorageSnapshot(reader, accountHash, storageHash)
-		if len(val) == 0 {
-			log.Debug("cannot find source snapshot?", "addr", accountHash, "key", storageHash, "epoch", epoch)
-			return 0, nil
-		}
-		valWithEpoch := NewValueWithEpoch(epoch, nil)
-		enc, err := EncodeValueToRLPBytes(valWithEpoch)
-		if err != nil {
-			return 0, err
-		}
-		rawdb.WriteStorageSnapshot(writer, accountHash, storageHash, enc)
-		shrinkSize := len(val) - len(enc)
-		if shrinkSize < 0 {
-			shrinkSize = 0
-		}
-		return int64(shrinkSize), nil
+func ShrinkExpiredLeaf(writer ethdb.KeyValueWriter, reader ethdb.KeyValueReader, accountHash common.Hash, storageHash common.Hash, cfg *types.StateExpiryConfig) (int64, error) {
+	if types.StateExpiryPruneLevel1 == cfg.PruneLevel {
+		return 0, nil
 	}
-	return 0, nil
+
+	rawdb.DeleteStorageSnapshot(writer, accountHash, storageHash)
+	return ContractSnapshotAvgSize, nil
 }

--- a/core/state/state_expiry.go
+++ b/core/state/state_expiry.go
@@ -30,6 +30,7 @@ type stateExpiryMeta struct {
 	epoch             types.StateEpoch
 	originalRoot      common.Hash
 	originalHash      common.Hash
+	pruneLevel        uint8
 }
 
 func defaultStateExpiryMeta() *stateExpiryMeta {
@@ -50,6 +51,7 @@ func tryReviveState(meta *stateExpiryMeta, addr common.Address, root common.Hash
 		case *trie.MissingNodeError:
 			// cannot revive locally, request from remote
 		case nil:
+			//log.Debug("tryReviveState localrevive", "addr", addr, "key", key, "val", common.BytesToHash(val), "err", err)
 			reviveFromLocalMeter.Mark(1)
 			return map[string][]byte{string(crypto.Keccak256(key[:])): val}, nil
 		default:

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -51,16 +51,15 @@ const (
 )
 
 var (
-	getCommittedStorageMeter                   = metrics.NewRegisteredMeter("state/contract/committed", nil)
-	getCommittedStorageSnapMeter               = metrics.NewRegisteredMeter("state/contract/committed/snap", nil)
-	getCommittedStorageTrieMeter               = metrics.NewRegisteredMeter("state/contract/committed/trie", nil)
-	getCommittedStorageExpiredMeter            = metrics.NewRegisteredMeter("state/contract/committed/expired", nil)
-	getCommittedStorageExpiredLocalReviveMeter = metrics.NewRegisteredMeter("state/contract/committed/expired/localrevive", nil)
-	getCommittedStorageUnexpiredMeter          = metrics.NewRegisteredMeter("state/contract/committed/unexpired", nil)
-	getCommittedStorageRemoteMeter             = metrics.NewRegisteredMeter("state/contract/committed/remote", nil)
-	storageReadMeter                           = metrics.NewRegisteredMeter("state/contract/state/read", nil)
-	storageWriteMeter                          = metrics.NewRegisteredMeter("state/contract/state/write", nil)
-	storageAccessMeter                         = metrics.NewRegisteredMeter("state/contract/state/access", nil)
+	getCommittedStorageMeter          = metrics.NewRegisteredMeter("state/contract/committed", nil)
+	getCommittedStorageSnapMeter      = metrics.NewRegisteredMeter("state/contract/committed/snap", nil)
+	getCommittedStorageTrieMeter      = metrics.NewRegisteredMeter("state/contract/committed/trie", nil)
+	getCommittedStorageExpiredMeter   = metrics.NewRegisteredMeter("state/contract/committed/expired", nil)
+	getCommittedStorageUnexpiredMeter = metrics.NewRegisteredMeter("state/contract/committed/unexpired", nil)
+	getCommittedStorageRemoteMeter    = metrics.NewRegisteredMeter("state/contract/committed/remote", nil)
+	storageReadMeter                  = metrics.NewRegisteredMeter("state/contract/state/read", nil)
+	storageWriteMeter                 = metrics.NewRegisteredMeter("state/contract/state/write", nil)
+	storageAccessMeter                = metrics.NewRegisteredMeter("state/contract/state/access", nil)
 )
 
 type revision struct {
@@ -269,6 +268,7 @@ func (s *StateDB) InitStateExpiryFeature(config *types.StateExpiryConfig, remote
 		epoch:             epoch,
 		originalRoot:      s.originalRoot,
 		originalHash:      startAtBlockHash,
+		pruneLevel:        config.PruneLevel,
 	}
 	//log.Debug("StateDB enable state expiry feature", "expectHeight", expectHeight, "startAtBlockHash", startAtBlockHash, "epoch", epoch)
 	return s

--- a/core/state/statedb.go
+++ b/core/state/statedb.go
@@ -58,6 +58,9 @@ var (
 	getCommittedStorageExpiredLocalReviveMeter = metrics.NewRegisteredMeter("state/contract/committed/expired/localrevive", nil)
 	getCommittedStorageUnexpiredMeter          = metrics.NewRegisteredMeter("state/contract/committed/unexpired", nil)
 	getCommittedStorageRemoteMeter             = metrics.NewRegisteredMeter("state/contract/committed/remote", nil)
+	storageReadMeter                           = metrics.NewRegisteredMeter("state/contract/state/read", nil)
+	storageWriteMeter                          = metrics.NewRegisteredMeter("state/contract/state/write", nil)
+	storageAccessMeter                         = metrics.NewRegisteredMeter("state/contract/state/access", nil)
 )
 
 type revision struct {

--- a/core/types/state_expiry.go
+++ b/core/types/state_expiry.go
@@ -9,9 +9,8 @@ import (
 )
 
 const (
-	StateExpiryPruneLevel0 = iota // StateExpiryPruneLevel0 is for HBSS, in HBSS we cannot prune any expired snapshot, it need rebuild trie for old tire node prune, it also cannot prune any shared trie node too.
-	StateExpiryPruneLevel1        // StateExpiryPruneLevel1 is the default level, it left some expired snapshot meta for performance friendly.
-	StateExpiryPruneLevel2        // StateExpiryPruneLevel2 will prune all expired snapshot kvs and trie nodes, but it will access more times in tire when execution. TODO(0xbundler): will support it later
+	StateExpiryPruneLevel0 = iota // StateExpiryPruneLevel0 is the default level, it will prune all expired snapshot kvs and trie nodes, but it will access more times in tire when execution. It not supports in HBSS.
+	StateExpiryPruneLevel1        // StateExpiryPruneLevel1 it left all snapshot & epoch meta for performance friendly.
 )
 
 type StateExpiryConfig struct {

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -234,6 +234,10 @@ func (b *EthAPIBackend) StorageTrie(stateRoot common.Hash, addr common.Address, 
 	return b.eth.BlockChain().StorageTrie(stateRoot, addr, root)
 }
 
+func (b *EthAPIBackend) StorageTrieAt(stateRoot common.Hash, addr common.Address) (state.Trie, error) {
+	return b.eth.BlockChain().StorageTrieAt(stateRoot, addr)
+}
+
 func (b *EthAPIBackend) GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error) {
 	return b.eth.blockchain.GetReceiptsByHash(hash), nil
 }

--- a/ethdb/fullstatedb.go
+++ b/ethdb/fullstatedb.go
@@ -86,7 +86,7 @@ func (f *FullStateRPCServer) GetStorageReviveProof(stateRoot common.Hash, accoun
 	}
 
 	// TODO(0xbundler): add timeout in flags?
-	ctx, cancelFunc := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	ctx, cancelFunc := context.WithTimeout(context.Background(), 300*time.Millisecond)
 	defer cancelFunc()
 	err := f.client.CallContext(ctx, &result, "eth_getStorageReviveProof", stateRoot, account, root, uncachedKeys, uncachedPrefixKeys)
 	if err != nil {

--- a/ethdb/fullstatedb.go
+++ b/ethdb/fullstatedb.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/metrics"
 	"github.com/ethereum/go-ethereum/rpc"
 	lru "github.com/hashicorp/golang-lru"
@@ -74,7 +73,6 @@ func (f *FullStateRPCServer) GetStorageReviveProof(stateRoot common.Hash, accoun
 	ret := make([]types.ReviveStorageProof, 0, len(keys))
 	for i, key := range keys {
 		val, ok := f.cache.Get(ProofCacheKey(account, root, prefixKeys[i], key))
-		log.Debug("GetStorageReviveProof hit cache", "account", account, "key", key, "ok", ok)
 		if !ok {
 			uncachedPrefixKeys = append(uncachedPrefixKeys, prefixKeys[i])
 			uncachedKeys = append(uncachedKeys, keys[i])
@@ -116,5 +114,13 @@ func ProofCacheKey(account common.Address, root common.Hash, prefix, key string)
 	buf.WriteString(common.No0xPrefix(prefix))
 	buf.WriteByte('$')
 	buf.WriteString(common.No0xPrefix(key))
+	return buf.String()
+}
+
+func ProofCacheTrie(blockRoot common.Hash, addr common.Address) string {
+	buf := bytes.NewBuffer(make([]byte, 0, len(blockRoot)+len(addr)+1))
+	buf.Write(blockRoot[:])
+	buf.WriteByte('$')
+	buf.Write(addr[:])
 	return buf.String()
 }

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -344,6 +344,10 @@ type testBackend struct {
 	pending *types.Block
 }
 
+func (b *testBackend) StorageTrieAt(stateRoot common.Hash, addr common.Address) (state.Trie, error) {
+	panic("implement me")
+}
+
 func newTestBackend(t *testing.T, n int, gspec *core.Genesis, generator func(i int, b *core.BlockGen)) *testBackend {
 	var (
 		engine      = ethash.NewFaker()

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -68,6 +68,7 @@ type Backend interface {
 	StateAndHeaderByNumber(ctx context.Context, number rpc.BlockNumber) (*state.StateDB, *types.Header, error)
 	StateAndHeaderByNumberOrHash(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash) (*state.StateDB, *types.Header, error)
 	StorageTrie(stateRoot common.Hash, addr common.Address, root common.Hash) (state.Trie, error)
+	StorageTrieAt(stateRoot common.Hash, addr common.Address) (state.Trie, error)
 	PendingBlockAndReceipts() (*types.Block, types.Receipts)
 	GetReceipts(ctx context.Context, hash common.Hash) (types.Receipts, error)
 	GetTd(ctx context.Context, hash common.Hash) *big.Int

--- a/internal/ethapi/transaction_args_test.go
+++ b/internal/ethapi/transaction_args_test.go
@@ -212,6 +212,10 @@ type backendMock struct {
 	config  *params.ChainConfig
 }
 
+func (b *backendMock) StorageTrieAt(stateRoot common.Hash, addr common.Address) (state.Trie, error) {
+	panic("implement me")
+}
+
 func newBackendMock() *backendMock {
 	config := &params.ChainConfig{
 		ChainID:             big.NewInt(42),

--- a/les/api_backend.go
+++ b/les/api_backend.go
@@ -49,6 +49,10 @@ type LesApiBackend struct {
 	gpo                 *gasprice.Oracle
 }
 
+func (b *LesApiBackend) StorageTrieAt(stateRoot common.Hash, addr common.Address) (state.Trie, error) {
+	panic("implement me")
+}
+
 func (b *LesApiBackend) ChainConfig() *params.ChainConfig {
 	return b.eth.chainConfig
 }

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -393,7 +393,9 @@ func NewHTTPHandlerStack(srv http.Handler, cors []string, vhosts []string, jwtSe
 	if len(jwtSecret) != 0 {
 		handler = newJWTHandler(jwtSecret, handler)
 	}
-	return newGzipHandler(handler)
+	//TODO(0xbundler): temporary disable state expiry ver gzip
+	//return newGzipHandler(handler)
+	return handler
 }
 
 // NewWSHandlerStack returns a wrapped ws-related handler.

--- a/node/rpcstack.go
+++ b/node/rpcstack.go
@@ -393,9 +393,7 @@ func NewHTTPHandlerStack(srv http.Handler, cors []string, vhosts []string, jwtSe
 	if len(jwtSecret) != 0 {
 		handler = newJWTHandler(jwtSecret, handler)
 	}
-	//TODO(0xbundler): temporary disable state expiry ver gzip
-	//return newGzipHandler(handler)
-	return handler
+	return newGzipHandler(handler)
 }
 
 // NewWSHandlerStack returns a wrapped ws-related handler.

--- a/rpc/client.go
+++ b/rpc/client.go
@@ -28,6 +28,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	jsoniter "github.com/json-iterator/go"
+
 	"github.com/ethereum/go-ethereum/log"
 )
 
@@ -371,6 +373,7 @@ func (c *Client) CallContext(ctx context.Context, result interface{}, method str
 		if result == nil {
 			return nil
 		}
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		return json.Unmarshal(resp.Result, result)
 	}
 }
@@ -453,6 +456,7 @@ func (c *Client) BatchCallContext(ctx context.Context, b []BatchElem) error {
 		case resp.Result == nil:
 			elem.Error = ErrNoResult
 		default:
+			var json = jsoniter.ConfigCompatibleWithStandardLibrary
 			elem.Error = json.Unmarshal(resp.Result, elem.Result)
 		}
 	}
@@ -549,6 +553,7 @@ func (c *Client) newMessage(method string, paramsIn ...interface{}) (*jsonrpcMes
 	msg := &jsonrpcMessage{Version: vsn, ID: c.nextID(), Method: method}
 	if paramsIn != nil { // prevent sending "params":null
 		var err error
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		if msg.Params, err = json.Marshal(paramsIn); err != nil {
 			return nil, err
 		}

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -25,6 +25,8 @@ import (
 	"sync"
 	"time"
 
+	jsoniter "github.com/json-iterator/go"
+
 	"github.com/ethereum/go-ethereum/common/gopool"
 
 	"github.com/ethereum/go-ethereum/log"
@@ -409,6 +411,7 @@ func (h *handler) handleResponses(batch []*jsonrpcMessage, handleCall func(*json
 			if msg.Error != nil {
 				op.err = msg.Error
 			} else {
+				var json = jsoniter.ConfigCompatibleWithStandardLibrary
 				op.err = json.Unmarshal(msg.Result, &op.sub.subid)
 				if op.err == nil {
 					go op.sub.run()
@@ -450,6 +453,7 @@ func (h *handler) handleResponses(batch []*jsonrpcMessage, handleCall func(*json
 // handleSubscriptionResult processes subscription notifications.
 func (h *handler) handleSubscriptionResult(msg *jsonrpcMessage) {
 	var result subscriptionResult
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	if err := json.Unmarshal(msg.Params, &result); err != nil {
 		h.log.Debug("Dropping invalid subscription message")
 		return

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -19,7 +19,6 @@ package rpc
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -30,6 +29,8 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	jsoniter "github.com/json-iterator/go"
 )
 
 const (
@@ -178,6 +179,7 @@ func (c *Client) sendHTTP(ctx context.Context, op *requestOp, msg interface{}) e
 
 	var resp jsonrpcMessage
 	batch := [1]*jsonrpcMessage{&resp}
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	if err := json.NewDecoder(respBody).Decode(&resp); err != nil {
 		return err
 	}
@@ -194,6 +196,7 @@ func (c *Client) sendBatchHTTP(ctx context.Context, op *requestOp, msgs []*jsonr
 	defer respBody.Close()
 
 	var respmsgs []*jsonrpcMessage
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	if err := json.NewDecoder(respBody).Decode(&respmsgs); err != nil {
 		return err
 	}
@@ -202,6 +205,7 @@ func (c *Client) sendBatchHTTP(ctx context.Context, op *requestOp, msgs []*jsonr
 }
 
 func (hc *httpConn) doRequest(ctx context.Context, msg interface{}) (io.ReadCloser, error) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	body, err := json.Marshal(msg)
 	if err != nil {
 		return nil, err
@@ -258,6 +262,7 @@ func newHTTPServerConn(r *http.Request, w http.ResponseWriter) ServerCodec {
 
 	encoder := func(v any, isErrorResponse bool) error {
 		if !isErrorResponse {
+			var json = jsoniter.ConfigCompatibleWithStandardLibrary
 			return json.NewEncoder(conn).Encode(v)
 		}
 
@@ -267,6 +272,7 @@ func newHTTPServerConn(r *http.Request, w http.ResponseWriter) ServerCodec {
 		// server's write timeout occurs. So we need to flush the response. The
 		// Content-Length header also needs to be set to ensure the client knows
 		// when it has the full response.
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		encdata, err := json.Marshal(v)
 		if err != nil {
 			return err
@@ -287,6 +293,7 @@ func newHTTPServerConn(r *http.Request, w http.ResponseWriter) ServerCodec {
 		return err
 	}
 
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	dec := json.NewDecoder(conn)
 	dec.UseNumber()
 

--- a/rpc/http.go
+++ b/rpc/http.go
@@ -218,7 +218,6 @@ func (hc *httpConn) doRequest(ctx context.Context, msg interface{}) (io.ReadClos
 	req.Header = hc.headers.Clone()
 	hc.mu.Unlock()
 	setHeaders(req.Header, headersFromContext(ctx))
-
 	if hc.auth != nil {
 		if err := hc.auth(req.Header); err != nil {
 			return nil, err

--- a/rpc/json.go
+++ b/rpc/json.go
@@ -27,6 +27,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	jsoniter "github.com/json-iterator/go"
 )
 
 const (
@@ -91,6 +93,7 @@ func (msg *jsonrpcMessage) namespace() string {
 }
 
 func (msg *jsonrpcMessage) String() string {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	b, _ := json.Marshal(msg)
 	return string(b)
 }
@@ -102,6 +105,7 @@ func (msg *jsonrpcMessage) errorResponse(err error) *jsonrpcMessage {
 }
 
 func (msg *jsonrpcMessage) response(result interface{}) *jsonrpcMessage {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	enc, err := json.Marshal(result)
 	if err != nil {
 		return msg.errorResponse(&internalServerError{errcodeMarshalError, err.Error()})
@@ -199,6 +203,7 @@ func NewFuncCodec(conn deadlineCloser, encode encodeFunc, decode decodeFunc) Ser
 // NewCodec creates a codec on the given connection. If conn implements ConnRemoteAddr, log
 // messages will use it to include the remote address of the connection.
 func NewCodec(conn Conn) ServerCodec {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	enc := json.NewEncoder(conn)
 	dec := json.NewDecoder(conn)
 	dec.UseNumber()
@@ -267,6 +272,7 @@ func (c *jsonCodec) closed() <-chan interface{} {
 func parseMessage(raw json.RawMessage) ([]*jsonrpcMessage, bool) {
 	if !isBatch(raw) {
 		msgs := []*jsonrpcMessage{{}}
+		var json = jsoniter.ConfigCompatibleWithStandardLibrary
 		json.Unmarshal(raw, &msgs[0])
 		return msgs, false
 	}

--- a/rpc/subscription.go
+++ b/rpc/subscription.go
@@ -29,6 +29,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	jsoniter "github.com/json-iterator/go"
 )
 
 var (
@@ -182,6 +184,7 @@ func (n *Notifier) activate() error {
 }
 
 func (n *Notifier) send(sub *Subscription, data json.RawMessage) error {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	params, _ := json.Marshal(&subscriptionResult{ID: string(sub.ID), Result: data})
 	ctx := context.Background()
 
@@ -208,6 +211,7 @@ func (s *Subscription) Err() <-chan error {
 
 // MarshalJSON marshals a subscription as its ID.
 func (s *Subscription) MarshalJSON() ([]byte, error) {
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	return json.Marshal(s.ID)
 }
 
@@ -376,6 +380,7 @@ func (sub *ClientSubscription) forward() (unsubscribeServer bool, err error) {
 
 func (sub *ClientSubscription) unmarshal(result json.RawMessage) (interface{}, error) {
 	val := reflect.New(sub.etype)
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err := json.Unmarshal(result, val.Interface())
 	return val.Elem().Interface(), err
 }

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -18,11 +18,12 @@ package rpc
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math"
 	"strconv"
 	"strings"
+
+	jsoniter "github.com/json-iterator/go"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -152,6 +153,7 @@ type BlockNumberOrHash struct {
 func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 	type erased BlockNumberOrHash
 	e := erased{}
+	var json = jsoniter.ConfigCompatibleWithStandardLibrary
 	err := json.Unmarshal(data, &e)
 	if err == nil {
 		if e.BlockNumber != nil && e.BlockHash != nil {

--- a/trie/secure_trie.go
+++ b/trie/secure_trie.go
@@ -327,5 +327,10 @@ func (t *StateTrie) TryRevive(key []byte, proof []*MPTProofNub) ([]*MPTProofNub,
 
 func (t *StateTrie) TryLocalRevive(_ common.Address, key []byte) ([]byte, error) {
 	key = t.hashKey(key)
-	return t.trie.TryLocalRevive(key)
+	enc, err := t.trie.TryLocalRevive(key)
+	if err != nil || len(enc) == 0 {
+		return nil, err
+	}
+	_, content, _, err := rlp.Split(enc)
+	return content, err
 }


### PR DESCRIPTION
### Description

State expiry mvp0.1: performance opt, support snapshot prunelevel1

### Changes

Notable changes: 
* trie/iterator: skip state expiry iter miss node;
* trie/iterator: fix local revive kv wrong issue;
* ethapi: opt getStorageProof in open storage trie;
* trie/tracer: trace node & blob;
* state/stateobject: support snap prune level0&level1;
* prune: opt prune logic for snap;
